### PR TITLE
Gh actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
 
     steps:
       - name: Checkout code
-      uses: actions/checkout@v2
+      - uses: actions/checkout@v2
 
       # Runs the Super-Linter action
       - name: Run Super-Linter

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,21 +5,6 @@ on:
   push:
 
 jobs:
-  super-lint:
-    name: Lint code base
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v2
-
-      # Runs the Super-Linter action
-      - name: Run Super-Linter
-        uses: github/super-linter@v3
-        env:
-          DEFAULT_BRANCH: develop
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
   pre-commit:
     name: Pre-commit checks
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,20 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+
+jobs:
+  super-lint:
+    name: Lint code base
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+      uses: actions/checkout@v2
+
+      # Runs the Super-Linter action
+      - name: Run Super-Linter
+        uses: github/super-linter@v3
+        env:
+          DEFAULT_BRANCH: develop

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,14 @@ jobs:
           DEFAULT_BRANCH: develop
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+  pre-commit:
+    name: pre-commit checks
+    - uses: actions/checkout@v2
+    - uses: actions/setup-python@v2
+    - uses: pre-commit/action@v2.0.0
+      with:
+        extra_args: --all-files
+
   unit-tests:
     name: Run unit tests
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,3 +18,4 @@ jobs:
         uses: github/super-linter@v3
         env:
           DEFAULT_BRANCH: develop
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,5 +85,3 @@ jobs:
       - name: Run tests with pytest
         run: |
           pytest -m "integration"
-
-

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,10 +21,20 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   pre-commit:
-    name: pre-commit checks
-    - uses: actions/checkout@v2
-    - uses: actions/setup-python@v2
-    - uses: pre-commit/action@v2.0.0
+    name: Pre-commit checks
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v2
+
+    - name: Install Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: '3.6'
+
+    - name: Run pre-commit
+      uses: pre-commit/action@v2.0.0
       with:
         extra_args: --all-files
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,6 +67,13 @@ jobs:
         run: |
           docker-compose up --build -d
 
+      - name: Dump docker logs before tests
+        uses: jwalton/gh-docker-logs@v1
+
       - name: Run tests with pytest
         run: |
           pytest -m "integration"
+
+      - name: Dump docker logs on failure
+        if: failure()
+        uses: jwalton/gh-docker-logs@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
 
     steps:
       - name: Checkout code
-      - uses: actions/checkout@v2
+        uses: actions/checkout@v2
 
       # Runs the Super-Linter action
       - name: Run Super-Linter

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,8 +35,8 @@ jobs:
 
       - name: Install deps
         run: |
-        python -m pip install --upgrade pip
-        pip install -r requirements.txt
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
 
       - name: Run tests with pytest
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,3 +19,26 @@ jobs:
         env:
           DEFAULT_BRANCH: develop
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  unit-tests:
+    name: Run unit tests
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Install Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.6'
+
+      - name: Install deps
+        run: |
+        python -m pip install --upgrade pip
+        pip install -r requirements.txt
+
+      - name: Run tests with pytest
+        run: |
+          pytest
+

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,3 +42,30 @@ jobs:
         run: |
           pytest
 
+  integration-tests:
+    name: Run integration tests
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Install Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.6'
+
+      - name: Install pytest
+        run: |
+          python -m pip install --upgrade pip
+          pip install pytest
+
+      - name: Build and run stack
+        run: |
+          docker-compose up --build -d
+
+      - name: Run tests with pytest
+        run: |
+          pytest -m "integration"
+
+

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,10 +55,10 @@ jobs:
         with:
           python-version: '3.6'
 
-      - name: Install pytest
+      - name: Install deps
         run: |
           python -m pip install --upgrade pip
-          pip install pytest
+          pip install -r requirements.txt
 
       - name: Build and run stack
         run: |

--- a/alfalfa_worker/requirements/production.txt
+++ b/alfalfa_worker/requirements/production.txt
@@ -11,6 +11,7 @@ idna==2.8
 importlib-metadata==1.4.0
 importlib-resources==1.0.2
 jmespath==0.9.4
+matplotlib
 mlep==0.1.dev2
 more-itertools==5.0.0
 nodeenv==1.3.4
@@ -25,10 +26,9 @@ requests==2.22.0
 s3transfer==0.3.0
 setuptools==44.0.0
 six==1.14.0
+symfit==0.5.3
 toml==0.10.0
 urllib3==1.25.7
 virtualenv==16.7.9
 wheel==0.34.2
 zipp==1.0.0
-symfit==0.5.3
-matplotlib

--- a/alfalfa_worker/requirements/production.txt
+++ b/alfalfa_worker/requirements/production.txt
@@ -17,7 +17,6 @@ nodeenv==1.3.4
 numpy==1.16.6  # need older version until Python > 3.5
 pandas==0.24.2  # need older version until Python > 3.5
 pymongo==3.10.1
-pysindy
 python-dateutil==2.8.1
 pytz==2019.3
 PyYAML==5.3

--- a/alfalfa_worker/requirements/production.txt
+++ b/alfalfa_worker/requirements/production.txt
@@ -11,7 +11,6 @@ idna==2.8
 importlib-metadata==1.4.0
 importlib-resources==1.0.2
 jmespath==0.9.4
-matplotlib
 mlep==0.1.dev2
 more-itertools==5.0.0
 nodeenv==1.3.4

--- a/alfalfa_worker/requirements/test.txt
+++ b/alfalfa_worker/requirements/test.txt
@@ -2,7 +2,7 @@
 
 # For testing the API -- use the git version of alfalfa-client
 # -e git+https://github.com/nrel/alfalfa-client.git@develop#egg=alfalfa-client
-alfalfa-client
+alfalfa-client==0.1.0.dev5
 
 # Testing and code syntax packages
 autopep8==1.4.4

--- a/alfalfa_worker/requirements/test.txt
+++ b/alfalfa_worker/requirements/test.txt
@@ -1,7 +1,6 @@
 -r production.txt
 
-# For testing the API -- use the git version of alfalfa-client
-# -e git+https://github.com/nrel/alfalfa-client.git@develop#egg=alfalfa-client
+# For testing the API
 alfalfa-client==0.1.0.dev5
 
 # Testing and code syntax packages

--- a/alfalfa_worker/requirements/test.txt
+++ b/alfalfa_worker/requirements/test.txt
@@ -1,8 +1,8 @@
 -r production.txt
 
 # For testing the API -- use the git version of alfalfa-client
--e git+https://github.com/nrel/alfalfa-client.git@develop#egg=alfalfa-client
-# alfalfa-client
+# -e git+https://github.com/nrel/alfalfa-client.git@develop#egg=alfalfa-client
+alfalfa-client
 
 # Testing and code syntax packages
 autopep8==1.4.4

--- a/alfalfa_worker/step_sim/osm_model_advancer.py
+++ b/alfalfa_worker/step_sim/osm_model_advancer.py
@@ -382,7 +382,7 @@ class OSMModelAdvancer(ModelAdvancer):
             self.ep.inputs[master_index] = 1
             for array in self.ac.mongo_db_write_arrays.find({"siteRef": self.site_id}):
                 for val in array.get('val'):
-                    if val:
+                    if val is not None:
                         index = self.variables.get_input_index(array.get('_id'))
                         if index == -1:
                             self.model_logger.logger.error('bad input index for: %s' % array.get('_id'))

--- a/tests/integration/test_rtu_coodination_osw.py
+++ b/tests/integration/test_rtu_coodination_osw.py
@@ -1,44 +1,44 @@
-import os
-import datetime
-import pytest
-import tempfile
-import zipfile
-from unittest import TestCase
-from alfalfa_client.alfalfa_client import AlfalfaClient
+# import os
+# import datetime
+# import pytest
+# import tempfile
+# import zipfile
+# from unittest import TestCase
+# from alfalfa_client.alfalfa_client import AlfalfaClient
 
 
-# Consider factoring this out of the test file
-def zipdir(path, ziph):
-    # ziph is zipfile handle
-    for root, dirs, files in os.walk(path):
-        for file in files:
-            ziph.write(os.path.join(root, file))
+# # Consider factoring this out of the test file
+# def zipdir(path, ziph):
+#     # ziph is zipfile handle
+#     for root, dirs, files in os.walk(path):
+#         for file in files:
+#             ziph.write(os.path.join(root, file))
 
 
-@pytest.mark.integration
-class TestRTUCoordinationOSW(TestCase):
+# @pytest.mark.integration
+# class TestRTUCoordinationOSW(TestCase):
 
-    def test_simple_internal_clock(self):
-        osw_dir_path = os.path.join(os.path.dirname(__file__), 'models', 'rtu_coordination_osw')
-        zip_file_fd, zip_file_path = tempfile.mkstemp(suffix='.zip')
+#     def test_simple_internal_clock(self):
+#         osw_dir_path = os.path.join(os.path.dirname(__file__), 'models', 'rtu_coordination_osw')
+#         zip_file_fd, zip_file_path = tempfile.mkstemp(suffix='.zip')
 
-        zipf = zipfile.ZipFile(zip_file_path, 'w', zipfile.ZIP_DEFLATED)
-        zipdir(osw_dir_path, zipf)
-        zipf.close()
+#         zipf = zipfile.ZipFile(zip_file_path, 'w', zipfile.ZIP_DEFLATED)
+#         zipdir(osw_dir_path, zipf)
+#         zipf.close()
 
-        alfalfa = AlfalfaClient(url='http://localhost')
-        model_id = alfalfa.submit(zip_file_path)
+#         alfalfa = AlfalfaClient(url='http://localhost')
+#         model_id = alfalfa.submit(zip_file_path)
 
-        alfalfa.wait(model_id, "Stopped")
+#         alfalfa.wait(model_id, "Stopped")
 
-        alfalfa.start(
-            model_id,
-            external_clock="false",
-            start_datetime=datetime.datetime(2019, 1, 2, 0, 0, 0),
-            end_datetime=datetime.datetime(2019, 1, 3, 0, 0, 0),
-            timescale=5
-        )
+#         alfalfa.start(
+#             model_id,
+#             external_clock="false",
+#             start_datetime=datetime.datetime(2019, 1, 2, 0, 0, 0),
+#             end_datetime=datetime.datetime(2019, 1, 3, 0, 0, 0),
+#             timescale=5
+#         )
 
-        alfalfa.wait(model_id, "Running")
-        alfalfa.stop(model_id)
-        alfalfa.wait(model_id, "Stopped")
+#         alfalfa.wait(model_id, "Running")
+#         alfalfa.stop(model_id)
+#         alfalfa.wait(model_id, "Stopped")

--- a/tests/integration/test_rtu_coodination_osw.py
+++ b/tests/integration/test_rtu_coodination_osw.py
@@ -4,7 +4,7 @@ import pytest
 import tempfile
 import zipfile
 from unittest import TestCase
-from alfalfa_client import AlfalfaClient
+from alfalfa_client.alfalfa_client import AlfalfaClient
 
 
 # Consider factoring this out of the test file

--- a/tests/integration/test_rtu_coodination_osw.py
+++ b/tests/integration/test_rtu_coodination_osw.py
@@ -1,44 +1,44 @@
-# import os
-# import datetime
-# import pytest
-# import tempfile
-# import zipfile
-# from unittest import TestCase
-# from alfalfa_client.alfalfa_client import AlfalfaClient
+import os
+import datetime
+import pytest
+import tempfile
+import zipfile
+from unittest import TestCase
+from alfalfa_client.alfalfa_client import AlfalfaClient
 
 
-# # Consider factoring this out of the test file
-# def zipdir(path, ziph):
-#     # ziph is zipfile handle
-#     for root, dirs, files in os.walk(path):
-#         for file in files:
-#             ziph.write(os.path.join(root, file))
+# Consider factoring this out of the test file
+def zipdir(path, ziph):
+    # ziph is zipfile handle
+    for root, dirs, files in os.walk(path):
+        for file in files:
+            ziph.write(os.path.join(root, file))
 
 
-# @pytest.mark.integration
-# class TestRTUCoordinationOSW(TestCase):
+@pytest.mark.integration
+class TestRTUCoordinationOSW(TestCase):
 
-#     def test_simple_internal_clock(self):
-#         osw_dir_path = os.path.join(os.path.dirname(__file__), 'models', 'rtu_coordination_osw')
-#         zip_file_fd, zip_file_path = tempfile.mkstemp(suffix='.zip')
+    def test_simple_internal_clock(self):
+        osw_dir_path = os.path.join(os.path.dirname(__file__), 'models', 'rtu_coordination_osw')
+        zip_file_fd, zip_file_path = tempfile.mkstemp(suffix='.zip')
 
-#         zipf = zipfile.ZipFile(zip_file_path, 'w', zipfile.ZIP_DEFLATED)
-#         zipdir(osw_dir_path, zipf)
-#         zipf.close()
+        zipf = zipfile.ZipFile(zip_file_path, 'w', zipfile.ZIP_DEFLATED)
+        zipdir(osw_dir_path, zipf)
+        zipf.close()
 
-#         alfalfa = AlfalfaClient(url='http://localhost')
-#         model_id = alfalfa.submit(zip_file_path)
+        alfalfa = AlfalfaClient(url='http://localhost')
+        model_id = alfalfa.submit(zip_file_path)
 
-#         alfalfa.wait(model_id, "Stopped")
+        alfalfa.wait(model_id, "Stopped")
 
-#         alfalfa.start(
-#             model_id,
-#             external_clock="false",
-#             start_datetime=datetime.datetime(2019, 1, 2, 0, 0, 0),
-#             end_datetime=datetime.datetime(2019, 1, 3, 0, 0, 0),
-#             timescale=5
-#         )
+        alfalfa.start(
+            model_id,
+            external_clock="false",
+            start_datetime=datetime.datetime(2019, 1, 2, 0, 0, 0),
+            end_datetime=datetime.datetime(2019, 1, 3, 0, 0, 0),
+            timescale=5
+        )
 
-#         alfalfa.wait(model_id, "Running")
-#         alfalfa.stop(model_id)
-#         alfalfa.wait(model_id, "Stopped")
+        alfalfa.wait(model_id, "Running")
+        alfalfa.stop(model_id)
+        alfalfa.wait(model_id, "Stopped")

--- a/tests/integration/test_simple_fmu_control.py
+++ b/tests/integration/test_simple_fmu_control.py
@@ -8,7 +8,8 @@ import sys
 import time
 from unittest import TestCase
 
-from alfalfa_client import AlfalfaClient, Historian
+from alfalfa_client.alfalfa_client import AlfalfaClient
+from alfalfa_client.historian import Historian
 from alfalfa_worker.lib.thermal_comfort import ThermalComfort
 from alfalfa_worker.lib.unit_conversions import deg_k_to_c
 

--- a/tests/integration/test_single_zone_vav_fmu.py
+++ b/tests/integration/test_single_zone_vav_fmu.py
@@ -1,7 +1,7 @@
 import os
 import pytest
 from unittest import TestCase
-from alfalfa_client import AlfalfaClient
+from alfalfa_client.alfalfa_client import AlfalfaClient
 
 
 @pytest.mark.integration

--- a/tests/integration/test_small_office_osm.py
+++ b/tests/integration/test_small_office_osm.py
@@ -2,7 +2,7 @@ import os
 import datetime
 import pytest
 from unittest import TestCase
-from alfalfa_client import AlfalfaClient
+from alfalfa_client.alfalfa_client import AlfalfaClient
 
 
 @pytest.mark.integration


### PR DESCRIPTION
Use GitHub Actions instead of Travis since Travis is no longer reliably free for NREL projects (limited free builds shared across organization).

I also removed the pysindy dependency which is necessary for one user but not broadly applicable.

Fixes #82. 