### PR TITLE
lock version of poetry and force install nodejs

### DIFF
--- a/alfalfa_web/Dockerfile
+++ b/alfalfa_web/Dockerfile
@@ -9,7 +9,7 @@ WORKDIR /root
 COPY alfalfa_web/package.json alfalfa_web/package-lock.json /root/
 
 RUN curl -sL https://deb.nodesource.com/setup_12.x | bash - \
-    && apt-get install -y ca-certificates nodejs \
+    && apt-get install -y --force-yes ca-certificates nodejs \
     && npm install
 
 COPY alfalfa_web /root

--- a/alfalfa_worker/Dockerfile
+++ b/alfalfa_worker/Dockerfile
@@ -69,7 +69,7 @@ COPY alfalfa_worker/requirements/py2-production.txt /alfalfa/
 # Reinstall/upgrade setuptools because this is needed for symfit (used in E+ Python)
 # Line 3 below installs python packages to the system and not in a virtualenv.
 RUN  python3 -m pip install --upgrade pip setuptools && \
-     python3 -m pip install poetry && \
+     python3 -m pip install poetry==1.1.4 && \
      python3 -m poetry config virtualenvs.create false && \
      python3 -m poetry install --no-dev
 # Python 2 dependencies


### PR DESCRIPTION
* Newer versions of poetry cause this build script to break, locking version for now.
* Need to force install node