### PR TITLE
Increase timeout for mlep to 1 min

### DIFF
--- a/alfalfa_worker/worker_openstudio/osm_model_advancer.py
+++ b/alfalfa_worker/worker_openstudio/osm_model_advancer.py
@@ -68,7 +68,7 @@ class OSMModelAdvancer(ModelAdvancerBase):
         self.ep = mlep.MlepProcess()
         self.ep.bcvtbDir = '/home/alfalfa/bcvtb/'
         self.ep.env = {'BCVTB_HOME': '/home/alfalfa/bcvtb'}
-        self.ep.accept_timeout = 30000
+        self.ep.accept_timeout = 60000
         self.ep.mapping = os.path.realpath(os.path.join(self.sim_path_site, 'simulation/haystack_report_mapping.json'))
         self.ep.workDir = os.path.split(self.idf_file)[0]
         self.ep.arguments = (self.idf_file, self.weather_file)


### PR DESCRIPTION
Larger models need more time for EnergyPlus to go through startup/warmup.
1 minute is arbitrary but probably enough for most models.

close #242