### PR TITLE
Check in run when error in job is experienced

### DIFF
--- a/alfalfa_worker/lib/job.py
+++ b/alfalfa_worker/lib/job.py
@@ -118,11 +118,13 @@ class Job(metaclass=JobMetaclass):
             self.logger.error(e.output)
             self.record_run_error(e.output)
             self.set_job_status(JobStatus.ERROR)
+            self.checkin_run()
         except Exception as e:
             self.logger.error(e, exc_info=True)
             self.logger.error(str(traceback.format_exc()))
             self.record_run_error(traceback.format_exc())
             self.set_job_status(JobStatus.ERROR)
+            self.checkin_run()
 
     def exec(self) -> None:
         """Runs job

--- a/tests/worker/jobs/log_reader_job.py
+++ b/tests/worker/jobs/log_reader_job.py
@@ -1,0 +1,13 @@
+from alfalfa_worker.lib.job import message
+from tests.worker.lib.mock_job import MockJob
+
+
+class LogReaderJob(MockJob):
+    def __init__(self, run_id):
+        super().__init__()
+        self.checkout_run(run_id)
+
+    @message
+    def read_job_log(self):
+        job_log_file = self.dir / 'jobs.log'
+        return job_log_file.read_text()

--- a/tests/worker/test_run.py
+++ b/tests/worker/test_run.py
@@ -1,7 +1,16 @@
+from uuid import uuid4
+
 from alfalfa_worker.dispatcher import Dispatcher
 from alfalfa_worker.lib.job import JobStatus
+from alfalfa_worker.lib.run import RunStatus
+from tests.worker.jobs.error_mock_job import ErrorMockJob
 from tests.worker.jobs.file_io_mock_job import FileIOMockJob
-from tests.worker.utilities import send_message_and_wait, wait_for_job_status
+from tests.worker.jobs.log_reader_job import LogReaderJob
+from tests.worker.utilities import (
+    send_message_and_wait,
+    wait_for_job_status,
+    wait_for_run_status
+)
 
 
 def test_run_file_conveyance(dispatcher: Dispatcher):
@@ -40,3 +49,26 @@ def test_run_file_conveyance(dispatcher: Dispatcher):
 
     file_io_job.stop()
     wait_for_job_status(file_io_job, JobStatus.STOPPED)
+
+
+def test_checkin_on_run_error(dispatcher: Dispatcher):
+    error_mock_job = dispatcher.create_job(ErrorMockJob.job_path())
+    error_mock_job.start()
+
+    run = error_mock_job.run
+
+    # generate a random string to look for in the error log
+    test_string = str(uuid4())
+
+    send_message_and_wait(error_mock_job, 'throw_error_with_value', {'value': test_string})
+
+    wait_for_run_status(run, RunStatus.ERROR)
+
+    log_reader_job = dispatcher.create_job(LogReaderJob.job_path(), {'run_id': run.id})
+    log_reader_job.start()
+
+    response = send_message_and_wait(log_reader_job, 'read_job_log')
+    log_contents = response['response']
+    log_reader_job.stop()
+
+    assert test_string in log_contents


### PR DESCRIPTION
- Added `self.checkin_run()` to error handling code.
- Added test which throws error and then confirms that error exists in `jobs.log` that was committed to the run
