### PR TITLE
InfluxDB auth breaks in Grafana 9.  This fixes the historian stack fo…

### DIFF
--- a/grafana/Dockerfile
+++ b/grafana/Dockerfile
@@ -1,4 +1,4 @@
-FROM grafana/grafana:latest
+FROM grafana/grafana:8.5.4
 
 # expose env vars during build for access during provisioning
 ARG INFLUXDB_HOST


### PR DESCRIPTION
…r 0.3.0.  Note Grafana will be retired in 0.4.0.