### PR TITLE
Python dependency management

### DIFF
--- a/alfalfa_worker/Dockerfile
+++ b/alfalfa_worker/Dockerfile
@@ -38,6 +38,7 @@ RUN apt-get update \
     python3.7-dev \
     python3.7 \
     python3.7-distutils \
+    python3.7-venv \
     python3-pip \
     libblas-dev \
     && rm -rf /var/lib/apt/lists/*

--- a/alfalfa_worker/jobs/openstudio/create_run.py
+++ b/alfalfa_worker/jobs/openstudio/create_run.py
@@ -33,7 +33,7 @@ class CreateRun(Job):
         # If there are requirements.txt files in the model create a python virtual environment and install packaged there
         requirements = self.run.glob("**/requirements.txt")
         if len(requirements) > 0:
-            check_call(["python", "-m", "venv", str(self.dir / '.venv')])
+            check_call(["python", "-m", "venv", "--system-site-packages", "--symlinks", str(self.dir / '.venv')])
             for requirements_file in requirements:
                 check_call([str(self.dir / '.venv' / 'bin' / 'pip'), "install", "-r", str(requirements_file)])
 

--- a/alfalfa_worker/jobs/openstudio/create_run.py
+++ b/alfalfa_worker/jobs/openstudio/create_run.py
@@ -26,6 +26,17 @@ class CreateRun(Job):
         else:
             raise JobExceptionInvalidModel("No .osw file found")
 
+        # create a "simulation" directory that has everything required for simulation
+        simulation_dir = self.dir / 'simulation'
+        simulation_dir.mkdir()
+
+        # If there are requirements.txt files in the model create a python virtual environment and install packaged there
+        requirements = self.run.glob("**/requirements.txt")
+        if len(requirements) > 0:
+            check_call(["python", "-m", "venv", str(self.dir / '.venv')])
+            for requirements_file in requirements:
+                check_call([str(self.dir / '.venv' / 'bin' / 'pip'), "install", "-r", str(requirements_file)])
+
         # locate the "default" workflow
         default_workflow_path: str = lib_dir / 'workflow/workflow.osw'
 
@@ -38,10 +49,6 @@ class CreateRun(Job):
         points_json_path = submitted_workflow_path / 'reports/haystack_report_haystack.json'
         mapping_json_path = submitted_workflow_path / 'reports/haystack_report_mapping.json'
         self.insert_os_tags(points_json_path, mapping_json_path)
-
-        # create a "simulation" directory that has everything required for simulation
-        simulation_dir = self.dir / 'simulation'
-        simulation_dir.mkdir()
 
         idf_src_path = submitted_workflow_path / 'run' / 'in.idf'
         idf_dest_path = simulation_dir / 'sim.idf'

--- a/alfalfa_worker/jobs/openstudio/lib/merge_osws.rb
+++ b/alfalfa_worker/jobs/openstudio/lib/merge_osws.rb
@@ -15,6 +15,9 @@ submitted_osw = OpenStudio::WorkflowJSON.new(submitted_osw_path)
 model_measure_type = OpenStudio::MeasureType.new('ModelMeasure')
 alfalfa_steps = alfalfa_osw.getMeasureSteps(model_measure_type)
 
+eplus_measure_type = OpenStudio::MeasureType.new('EnergyPlusMeasure')
+alfalfa_eplus_steps = alfalfa_osw.getMeasureSteps(eplus_measure_type)
+
 # Given a WorkflowJSON, return the local measures directory relative to the osw
 # The goal is to avoid any global directories that are outside of the osw directory
 def measures_directory(osw)
@@ -35,8 +38,16 @@ alfalfa_steps.each do |step|
   FileUtils.cp_r(bcl_measure_path, measures_directory(submitted_osw))
 end
 
+alfalfa_eplus_steps.each do |step|
+  bcl_measure = alfalfa_osw.getBCLMeasure(step).get()
+  bcl_measure_path = OpenStudio::toString(bcl_measure.directory())
+  FileUtils.cp_r(bcl_measure_path, measures_directory(submitted_osw))
+end
+
 submitted_steps = submitted_osw.getMeasureSteps(model_measure_type)
+submitted_eplus_steps = submitted_osw.getMeasureSteps(eplus_measure_type)
 new_steps = submitted_steps + alfalfa_steps
 submitted_osw.setMeasureSteps(model_measure_type, new_steps)
+submitted_osw.setMeasureSteps(eplus_measure_type, submitted_eplus_steps + alfalfa_eplus_steps)
 
 submitted_osw.save()

--- a/alfalfa_worker/jobs/openstudio/lib/workflow/measures/python/measure.rb
+++ b/alfalfa_worker/jobs/openstudio/lib/workflow/measures/python/measure.rb
@@ -71,13 +71,13 @@ class Python < OpenStudio::Ruleset::WorkspaceUserScript
 
     # modify python plugin search paths
     ws.getObjectsByType('PythonPlugin_SearchPaths'.to_IddObjectType).each do |o|
-      o.setString(o.numFields(), "../.venv/lib/python3.7/site-packages")
-      i = 0
-      runner.workflow.absoluteFilePaths.each do |p|
-        if p.to_s.include?('python')
-          o.setString(4 + i, p.to_s)
-          i += 1
+      python_paths = ["../.venv/lib/python3.7/site-packages", "/usr/local/lib/python3.7/dist-packages"]
+      i = 3
+      while python_paths.length() > 0 && i < 20 do
+        if o.getString(i, false, true).empty?
+          o.setString(i, python_paths.pop)
         end
+        i += 1
       end
     end
   end

--- a/alfalfa_worker/jobs/openstudio/lib/workflow/measures/python/measure.rb
+++ b/alfalfa_worker/jobs/openstudio/lib/workflow/measures/python/measure.rb
@@ -1,0 +1,88 @@
+# *******************************************************************************
+# OpenStudio(R), Copyright (c) 2008-2020, Alliance for Sustainable Energy, LLC.
+# All rights reserved.
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# (1) Redistributions of source code must retain the above copyright notice,
+# this list of conditions and the following disclaimer.
+#
+# (2) Redistributions in binary form must reproduce the above copyright notice,
+# this list of conditions and the following disclaimer in the documentation
+# and/or other materials provided with the distribution.
+#
+# (3) Neither the name of the copyright holder nor the names of any contributors
+# may be used to endorse or promote products derived from this software without
+# specific prior written permission from the respective party.
+#
+# (4) Other than as required in clauses (1) and (2), distributions in any form
+# of modifications or other derivative works may not use the "OpenStudio"
+# trademark, "OS", "os", or any other confusingly similar designation without
+# specific prior written permission from Alliance for Sustainable Energy, LLC.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDER(S) AND ANY CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+# THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER(S), ANY CONTRIBUTORS, THE
+# UNITED STATES GOVERNMENT, OR THE UNITED STATES DEPARTMENT OF ENERGY, NOR ANY OF
+# THEIR EMPLOYEES, BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+# EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+# OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+# STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+# OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+# *******************************************************************************
+
+# start the measure
+class Python < OpenStudio::Ruleset::WorkspaceUserScript
+
+  # human readable name
+  def name
+    return 'Python'
+  end
+
+  # human readable description
+  def description
+    return 'Add python to IDF'
+  end
+
+  # human readable description of modeling approach
+  def modeler_description
+    return 'Add python script path to IDF'
+  end
+
+  # define the arguments that the user will input
+  def arguments(workspace)
+    args = OpenStudio::Ruleset::OSArgumentVector.new
+    return args
+  end
+
+  # define what happens when the measure is run
+  def run(ws, runner, user_args)
+
+    # call the parent class method
+    super(ws, runner, user_args)
+
+    # use the built-in error checking
+    return false unless runner.validateUserArguments(
+      arguments(ws),
+      user_args
+    )
+
+    # modify python plugin search paths
+    ws.getObjectsByType('PythonPlugin_SearchPaths'.to_IddObjectType).each do |o|
+      o.setString(o.numFields(), "../.venv/lib/python3.7/site-packages")
+      i = 0
+      runner.workflow.absoluteFilePaths.each do |p|
+        if p.to_s.include?('python')
+          o.setString(4 + i, p.to_s)
+          i += 1
+        end
+      end
+    end
+  end
+
+end
+
+# register the measure to be used by the application
+Python.new.registerWithApplication

--- a/alfalfa_worker/jobs/openstudio/lib/workflow/measures/python/measure.xml
+++ b/alfalfa_worker/jobs/openstudio/lib/workflow/measures/python/measure.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0"?>
+<measure>
+  <schema_version>3.0</schema_version>
+  <name>python</name>
+  <uid>16125428-fcf9-4986-9d9b-3644225a2b6d</uid>
+  <version_id>d307d444-42fa-4805-8ada-e34a39d97424</version_id>
+  <version_modified>20220804T163944Z</version_modified>
+  <xml_checksum>9D2F1A23</xml_checksum>
+  <class_name>Python</class_name>
+  <display_name>Python</display_name>
+  <description>Add python to IDF</description>
+  <modeler_description>Add python script path to IDF</modeler_description>
+  <arguments>
+    <argument>
+      <name>python_path</name>
+      <display_name>Python Path</display_name>
+      <description>Path to python site-packages</description>
+      <type>String</type>
+      <required>true</required>
+      <model_dependent>false</model_dependent>
+    </argument>
+  </arguments>
+  <outputs />
+  <provenances />
+  <tags />
+  <attributes>
+    <attribute>
+      <name>Measure Type</name>
+      <value>EnergyPlusMeasure</value>
+      <datatype>string</datatype>
+    </attribute>
+    <attribute>
+      <name>Intended Software Tool</name>
+      <value>OpenStudio Application</value>
+      <datatype>string</datatype>
+    </attribute>
+  </attributes>
+  <files>
+    <file>
+      <version>
+        <software_program>OpenStudio</software_program>
+        <identifier>2.3.0</identifier>
+        <min_compatible>2.3.0</min_compatible>
+      </version>
+      <filename>measure.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>script</usage_type>
+      <checksum>319CFDB7</checksum>
+    </file>
+  </files>
+</measure>

--- a/alfalfa_worker/jobs/openstudio/lib/workflow/workflow.osw
+++ b/alfalfa_worker/jobs/openstudio/lib/workflow/workflow.osw
@@ -24,6 +24,13 @@
          "measure_dir_name" : "export_bcvtb",
          "modeler_description" : "This measure loops through outputvariables, EMS:outputvariables and ExternalInterface objects and will create the variables.cfg xml file for BCVTB.",
          "name" : "ExportBCVTB"
+      },
+      {
+         "arguments" : {},
+         "measure_dir_name" : "python",
+         "name" : "Python",
+         "description" : "Add python to IDF",
+         "modeler_description" : "Add python script path to IDF"
       }
    ],
    "updated_at" : "20170606T230145Z",


### PR DESCRIPTION
Addresses #110 

When a OpenStudio run is created the job checks for any `requirements.txt` files. If any are found it creates a virtual environment in the run directory and installs packages. The E+ idf is then modified to point to that directory via its python path. This could and should be used by energy modelers to get their python dependencies into alfalfa. The main goal is to make it possible to add dependencies without having to create custom images and restarting the server.

The main downside (that I can see) from this change is that models which take advantage of this will have significantly larger than those without a virtual environment. This is because the entire environment is packaged with the run. One alternative would be to install packages worker wide, however, this would mean that packages would need to be installed on every worker and it would introduce the possibility of weird python dependency conflicts between models.

If this gets merged I will add wiki docs to the openstudio section. 