### PR TITLE
Pass realtime, external_clock, and timescale as string

### DIFF
--- a/alfalfa_web/server/api-v2.js
+++ b/alfalfa_web/server/api-v2.js
@@ -296,9 +296,9 @@ router.post("/models/:id/start", async (req, res) => {
         "run_id": "${modelId}",
         "start_datetime": "${startDatetime}",
         "end_datetime": "${endDatetime}",
-        "timescale": ${timescale || 5},
-        "realtime": ${!!realtime},
-        "external_clock": ${!!externalClock}
+        "timescale": "${timescale || 5}",
+        "realtime": "${!!realtime}",
+        "external_clock": "${!!externalClock}"
       }
     }`,
     QueueUrl: process.env.JOB_QUEUE_URL,

--- a/alfalfa_web/server/resolvers.js
+++ b/alfalfa_web/server/resolvers.js
@@ -83,11 +83,11 @@ function runSiteResolver(args, context) {
         "job": "${job}",
         "params": {
           "run_id": "${args.siteRef}",
-          "timescale": ${args.timescale},
+          "timescale": "${args.timescale}",
           "start_datetime": "${args.startDatetime}",
           "end_datetime": "${args.endDatetime}",
-          "realtime": ${args.realtime},
-          "external_clock": ${args.externalClock}
+          "realtime": "${args.realtime}",
+          "external_clock": "${args.externalClock}"
         }
       }`,
       QueueUrl: process.env.JOB_QUEUE_URL,

--- a/alfalfa_web/server/resolvers.js
+++ b/alfalfa_web/server/resolvers.js
@@ -83,11 +83,11 @@ function runSiteResolver(args, context) {
         "job": "${job}",
         "params": {
           "run_id": "${args.siteRef}",
-          "timescale": "${args.timescale}",
+          "timescale": "${args.timescale || 5}",
           "start_datetime": "${args.startDatetime}",
           "end_datetime": "${args.endDatetime}",
-          "realtime": "${args.realtime}",
-          "external_clock": "${args.externalClock}"
+          "realtime": "${!!args.realtime}",
+          "external_clock": "${!!args.externalClock}"
         }
       }`,
       QueueUrl: process.env.JOB_QUEUE_URL,

--- a/alfalfa_worker/jobs/step_run_base.py
+++ b/alfalfa_worker/jobs/step_run_base.py
@@ -37,26 +37,24 @@ class StepRunBase(Job):
         # TODO change server side message: startDatetime to start_datetime
         timescale = False if timescale == 'undefined' else timescale
 
-        # TODO remove after tests written
-        self.logger.info(
-            "start_datetime type: {}\tstart_datetime: {}".format(type(start_datetime), start_datetime))
-        self.logger.info(
-            "end_datetime type: {}\tend_datetime: {}".format(type(end_datetime), end_datetime))
-        self.logger.info("realtime type: {}\trealtime: {}".format(type(realtime), realtime))
-        self.logger.info("timescale type: {}\ttimescale: {}".format(type(timescale), timescale))
-        self.logger.info(
-            "external_clock type: {}\texternal_clock: {}".format(type(external_clock), external_clock))
-        # Only want one of: realtime, timescale, or external_clock.  Else, reject configuration.
-        # if (realtime and timescale) or (realtime and external_clock) or (timescale and external_clock):
-        #    self.logger.info(
-        #        "Only one of 'external_clock', 'timescale', or 'realtime' should be specified in message")
-        #    sys.exit(1)
+        # make sure the inputs are typed correctly
+        try:
+            timescale = int(timescale)
+        except ValueError:
+            self.logger.info(f"timescale is not an integer, continuing as sim_type=timescale. Value was {timescale}")
+
+        realtime = True if realtime and realtime.lower() == 'true' else False
+        external_clock = True if external_clock and external_clock.lower() == 'true' else False
+
+        self.logger.debug("start_datetime type: {}\tstart_datetime: {}".format(type(start_datetime), start_datetime))
+        self.logger.debug("end_datetime type: {}\tend_datetime: {}".format(type(end_datetime), end_datetime))
+        self.logger.debug("realtime type: {}\trealtime: {}".format(type(realtime), realtime))
+        self.logger.debug("timescale type: {}\ttimescale: {}".format(type(timescale), timescale))
+        self.logger.debug("external_clock type: {}\texternal_clock: {}".format(type(external_clock), external_clock))
 
         # Check for at least one of the required parameters
         if not realtime and not timescale and not external_clock:
-            # TODO: If exiting, what logging type to use?
-            self.logger.info(
-                "At least one of 'external_clock', 'timescale', or 'realtime' must be specified")
+            self.logger.error("At least one of 'external_clock', 'timescale', or 'realtime' must be specified")
             raise JobException("At least one of 'external_clock', 'timescale', or 'realtime' must be specified")
 
         if external_clock:

--- a/alfalfa_worker/jobs/step_run_base.py
+++ b/alfalfa_worker/jobs/step_run_base.py
@@ -43,14 +43,16 @@ class StepRunBase(Job):
         except ValueError:
             self.logger.info(f"timescale is not an integer, continuing as sim_type=timescale. Value was {timescale}")
 
-        realtime = True if realtime and realtime.lower() == 'true' else False
-        external_clock = True if external_clock and external_clock.lower() == 'true' else False
+        if not isinstance(realtime, bool):
+            realtime = True if realtime and realtime.lower() == 'true' else False
+        if not isinstance(external_clock, bool):
+            external_clock = True if external_clock and external_clock.lower() == 'true' else False
 
-        self.logger.debug("start_datetime type: {}\tstart_datetime: {}".format(type(start_datetime), start_datetime))
-        self.logger.debug("end_datetime type: {}\tend_datetime: {}".format(type(end_datetime), end_datetime))
-        self.logger.debug("realtime type: {}\trealtime: {}".format(type(realtime), realtime))
-        self.logger.debug("timescale type: {}\ttimescale: {}".format(type(timescale), timescale))
-        self.logger.debug("external_clock type: {}\texternal_clock: {}".format(type(external_clock), external_clock))
+        self.logger.debug(f"start_datetime type: {type(start_datetime)}\tstart_datetime: {start_datetime}")
+        self.logger.debug(f"end_datetime type: {type(end_datetime)}\tend_datetime: {end_datetime}")
+        self.logger.debug(f"realtime type: {type(realtime)}\trealtime: {realtime}")
+        self.logger.debug(f"timescale type: {type(timescale)}\ttimescale: {timescale}")
+        self.logger.debug(f"external_clock type: {type(external_clock)}\texternal_clock: {external_clock}")
 
         # Check for at least one of the required parameters
         if not realtime and not timescale and not external_clock:


### PR DESCRIPTION
There have been some exceptions raised saving the messages with types other than strings. This enforces the data to pass as strings, then typed correctly on the other side.