### PR TITLE
Small Optimization for Point Writing

### DIFF
--- a/alfalfa_worker/jobs/openstudio/step_run.py
+++ b/alfalfa_worker/jobs/openstudio/step_run.py
@@ -307,10 +307,6 @@ class StepRun(StepRunBase):
                     rec__cur="m:"
                 )
 
-                # Write to points
-                self.run.get_point_by_key(output_id).val = output_value
-                self.run_manager.update_db(self.run)
-
     def update_sim_time_in_mongo(self):
         """Placeholder for updating the datetime in Mongo to current simulation time"""
         output_time_string = "s:" + str(self.get_sim_time())


### PR DESCRIPTION
We were still writing to mongo for every output point for every step. This seems to provide a speed up in my limited testing of greater than 20 times. I can now run the refrig_test model at over 300x realtime on my machine when I couldn't run at more than 15x before.

I discovered this while working on PR #364 