### PR TITLE
Change python measure name

### DIFF
--- a/alfalfa_worker/jobs/openstudio/create_run.py
+++ b/alfalfa_worker/jobs/openstudio/create_run.py
@@ -1,7 +1,7 @@
 import json
 import os
 from pathlib import Path
-from subprocess import check_call
+from subprocess import check_output
 
 from alfalfa_worker.jobs.openstudio import lib_dir
 from alfalfa_worker.lib.job import Job, JobExceptionInvalidModel
@@ -33,18 +33,18 @@ class CreateRun(Job):
         # If there are requirements.txt files in the model create a python virtual environment and install packaged there
         requirements = self.run.glob("**/requirements.txt")
         if len(requirements) > 0:
-            check_call(["python", "-m", "venv", "--system-site-packages", "--symlinks", str(self.dir / '.venv')])
+            check_output(["python", "-m", "venv", "--system-site-packages", "--symlinks", str(self.dir / '.venv')])
             for requirements_file in requirements:
-                check_call([str(self.dir / '.venv' / 'bin' / 'pip'), "install", "-r", str(requirements_file)])
+                check_output([str(self.dir / '.venv' / 'bin' / 'pip'), "install", "-r", str(requirements_file)])
 
         # locate the "default" workflow
         default_workflow_path: str = lib_dir / 'workflow/workflow.osw'
 
         # Merge the default workflow measures into the user submitted workflow
-        check_call(['openstudio', str(lib_dir / 'merge_osws.rb'), str(default_workflow_path), str(submitted_osw_path)])
+        check_output(['openstudio', str(lib_dir / 'merge_osws.rb'), str(default_workflow_path), str(submitted_osw_path)])
 
         # run workflow
-        check_call(['openstudio', 'run', '-m', '-w', str(submitted_osw_path)])
+        check_output(['openstudio', 'run', '-m', '-w', str(submitted_osw_path)])
 
         points_json_path = submitted_workflow_path / 'reports/haystack_report_haystack.json'
         mapping_json_path = submitted_workflow_path / 'reports/haystack_report_mapping.json'

--- a/alfalfa_worker/jobs/openstudio/lib/workflow/measures/alfalfa_python_environment/measure.rb
+++ b/alfalfa_worker/jobs/openstudio/lib/workflow/measures/alfalfa_python_environment/measure.rb
@@ -34,16 +34,16 @@
 # *******************************************************************************
 
 # start the measure
-class Python < OpenStudio::Ruleset::WorkspaceUserScript
+class AlfalfaPythonEnvironment < OpenStudio::Ruleset::WorkspaceUserScript
 
   # human readable name
   def name
-    return 'Python'
+    return 'Alfalfa Python Environment'
   end
 
   # human readable description
   def description
-    return 'Add python to IDF'
+    return 'Add alfalfa python environment to IDF'
   end
 
   # human readable description of modeling approach

--- a/alfalfa_worker/jobs/openstudio/lib/workflow/measures/alfalfa_python_environment/measure.rb
+++ b/alfalfa_worker/jobs/openstudio/lib/workflow/measures/alfalfa_python_environment/measure.rb
@@ -92,4 +92,4 @@ class AlfalfaPythonEnvironment < OpenStudio::Ruleset::WorkspaceUserScript
 end
 
 # register the measure to be used by the application
-Python.new.registerWithApplication
+AlfalfaPythonEnvironment.new.registerWithApplication

--- a/alfalfa_worker/jobs/openstudio/lib/workflow/measures/alfalfa_python_environment/measure.xml
+++ b/alfalfa_worker/jobs/openstudio/lib/workflow/measures/alfalfa_python_environment/measure.xml
@@ -1,25 +1,17 @@
 <?xml version="1.0"?>
 <measure>
   <schema_version>3.0</schema_version>
-  <name>python</name>
+  <error>uninitialized constant Python</error>
+  <name>alfalfa_python_environment</name>
   <uid>16125428-fcf9-4986-9d9b-3644225a2b6d</uid>
-  <version_id>d307d444-42fa-4805-8ada-e34a39d97424</version_id>
-  <version_modified>20220804T163944Z</version_modified>
+  <version_id>310e60b6-6215-4d58-b10b-e21eddaaf129</version_id>
+  <version_modified>20221031T173904Z</version_modified>
   <xml_checksum>9D2F1A23</xml_checksum>
-  <class_name>Python</class_name>
-  <display_name>Python</display_name>
-  <description>Add python to IDF</description>
+  <class_name>AlfalfaPythonEnvironment</class_name>
+  <display_name>Alfalfa Python Environment</display_name>
+  <description>Add alfalfa python environment to IDF</description>
   <modeler_description>Add python script path to IDF</modeler_description>
-  <arguments>
-    <argument>
-      <name>python_path</name>
-      <display_name>Python Path</display_name>
-      <description>Path to python site-packages</description>
-      <type>String</type>
-      <required>true</required>
-      <model_dependent>false</model_dependent>
-    </argument>
-  </arguments>
+  <arguments />
   <outputs />
   <provenances />
   <tags />
@@ -45,7 +37,7 @@
       <filename>measure.rb</filename>
       <filetype>rb</filetype>
       <usage_type>script</usage_type>
-      <checksum>319CFDB7</checksum>
+      <checksum>4A5B6A8D</checksum>
     </file>
   </files>
 </measure>

--- a/alfalfa_worker/jobs/openstudio/lib/workflow/workflow.osw
+++ b/alfalfa_worker/jobs/openstudio/lib/workflow/workflow.osw
@@ -27,7 +27,7 @@
       },
       {
          "arguments" : {},
-         "measure_dir_name" : "python",
+         "measure_dir_name" : "alfalfa_python_environment",
          "name" : "Python",
          "description" : "Add python to IDF",
          "modeler_description" : "Add python script path to IDF"

--- a/alfalfa_worker/lib/job.py
+++ b/alfalfa_worker/lib/job.py
@@ -115,8 +115,8 @@ class Job(metaclass=JobMetaclass):
             self.set_job_status(JobStatus.STOPPED)
 
         except CalledProcessError as e:
-            self.logger.error(e.output)
-            self.record_run_error(e.output)
+            self.logger.error(e.output.decode('utf-8'))
+            self.record_run_error(e.output.decode('utf-8'))
             self.set_job_status(JobStatus.ERROR)
             self.checkin_run()
         except Exception as e:

--- a/alfalfa_worker/lib/job.py
+++ b/alfalfa_worker/lib/job.py
@@ -115,8 +115,14 @@ class Job(metaclass=JobMetaclass):
             self.set_job_status(JobStatus.STOPPED)
 
         except CalledProcessError as e:
-            self.logger.error(e.output.decode('utf-8'))
-            self.record_run_error(e.output.decode('utf-8'))
+            if e.output:
+                self.logger.error(e, exc_info=True)
+                self.logger.error(e.output.decode('utf-8'))
+                self.record_run_error(e.output.decode('utf-8'))
+            else:
+                self.logger.error(e, exc_info=True)
+                self.logger.error(str(traceback.format_exc()))
+                self.record_run_error(traceback.format_exc())
             self.set_job_status(JobStatus.ERROR)
             self.checkin_run()
         except Exception as e:

--- a/tests/worker/jobs/subprocess_mock_job.py
+++ b/tests/worker/jobs/subprocess_mock_job.py
@@ -1,4 +1,4 @@
-from subprocess import check_call
+from subprocess import check_call, check_output
 
 from alfalfa_worker.lib.job import message
 from tests.worker.lib.mock_job import MockJob
@@ -20,6 +20,11 @@ class SubprocessMockJob(MockJob):
     @message
     def failing_subprocess(self):
         check_call("exit 1", shell=True)
+        return True
+
+    @message
+    def failing_subprocess_with_output(self, test_string):
+        check_output(f"echo '{test_string}' && exit 1", shell=True)
         return True
 
     @message

--- a/tests/worker/test_job_subprocess_calls.py
+++ b/tests/worker/test_job_subprocess_calls.py
@@ -1,3 +1,5 @@
+from uuid import uuid4
+
 from alfalfa_worker.dispatcher import Dispatcher
 from alfalfa_worker.lib.job import JobStatus
 from tests.worker.jobs.subprocess_mock_job import SubprocessMockJob
@@ -42,3 +44,20 @@ def test_subprocess_call_error_2(dispatcher: Dispatcher):
     assert response['response'] != 'True'
     assert response['status'] == 'error'
     wait_for_job_status(subprocess_job, JobStatus.ERROR)
+
+
+def test_subprocess_call_error_3(dispatcher: Dispatcher):
+    subprocess_job = dispatcher.create_job(SubprocessMockJob.job_path())
+    subprocess_job.start()
+
+    wait_for_job_status(subprocess_job, JobStatus.WAITING)
+
+    test_string = str(uuid4())
+
+    response = send_message_and_wait(subprocess_job, 'failing_subprocess_with_output', {"test_string": test_string})
+    assert response['response'] != 'True'
+    assert response['status'] == 'error'
+
+    wait_for_job_status(subprocess_job, JobStatus.ERROR)
+
+    assert test_string in subprocess_job.run.error_log


### PR DESCRIPTION
the measure for adding python environment to the idf was called `python` this is a pretty common measure name for projects using python. If there are two measures with the same directory name things break very badly. So I'm changing the measure name to `alfalfa_python_environment`.