### PR TITLE
Move from sklearn to scikit-learn in test

### DIFF
--- a/tests/integration/models/small_office/measures/python_ems/resources/requirements.txt
+++ b/tests/integration/models/small_office/measures/python_ems/resources/requirements.txt
@@ -1,1 +1,1 @@
-sklearn
+scikit-learn


### PR DESCRIPTION
Apparently installing from `sklearn` was EOLed two hours ago. This broke the python environment integration test. This should fix that by point to the new repo.