### PR TITLE
Temporarily remove automatic natural gas metering

### DIFF
--- a/alfalfa_worker/jobs/openstudio/lib/workflow/measures/alfalfa_site_sensors/measure.rb
+++ b/alfalfa_worker/jobs/openstudio/lib/workflow/measures/alfalfa_site_sensors/measure.rb
@@ -58,8 +58,7 @@ class AlfalfaSiteSensors < OpenStudio::Measure::EnergyPlusMeasure
     end
 
     fuels = [
-      'Electricity',
-      'NaturalGas'
+      'Electricity'
     ]
 
     fuels.each do |fuel|


### PR DESCRIPTION
Buildings which do not have natural gas equipment will error out if a sensor reading the natural gas meter is added.

In the future we could re add with some logic about when to add the natural gas meter.