### PR TITLE
Report preprocessing errors and consolidate site information collection

### DIFF
--- a/alfalfa_web/components/Sites/Sites.js
+++ b/alfalfa_web/components/Sites/Sites.js
@@ -134,7 +134,10 @@ export const Sites = () => {
                   <TableCell>{site.id}</TableCell>
                   <TableCell>
                     {site.status === "error" && site.errorLog ? (
-                      <Button variant="text" onClick={(event) => handleOpenErrorDialog(event, site)}>
+                      <Button
+                        variant="text"
+                        style={{ marginLeft: -9 }}
+                        onClick={(event) => handleOpenErrorDialog(event, site)}>
                         {site.status.toUpperCase()}
                       </Button>
                     ) : (

--- a/alfalfa_web/server/api.js
+++ b/alfalfa_web/server/api.js
@@ -75,9 +75,10 @@ class AlfalfaAPI {
 
         if (site) {
           const siteHash = await getHash(this.redis, siteRef);
+          site = mapHaystack(site);
 
-          site_dict.name = site?.dis;
-          site_dict.datetime = siteHash?.sim_time;
+          site_dict.name = site?.dis ?? site_dict.name;
+          site_dict.datetime = siteHash?.sim_time ?? "";
         }
         return site_dict;
       }

--- a/alfalfa_web/server/api.js
+++ b/alfalfa_web/server/api.js
@@ -41,27 +41,11 @@ class AlfalfaAPI {
     try {
       const runs = [];
 
-      const models = (await this.models.find().toArray()).reduce(reduceById, {});
-      const sites = (await this.sites.find().toArray()).map(mapHaystack).reduce(reduceByRefId, {});
-
       for await (const run of this.runs.find()) {
-        const siteRef = run.ref_id;
-        const model = models[run.model];
-        const site = sites[siteRef];
+        const site = await this.findSite(run.ref_id);
 
         if (site) {
-          const siteHash = await getHash(this.redis, siteRef);
-
-          runs.push({
-            id: siteRef,
-            name: site.dis,
-            status: run.status.toLowerCase(),
-            simType: site.sim_type,
-            datetime: siteHash?.sim_time ?? "",
-            uploadTimestamp: run.created,
-            uploadPath: `uploads/${model.ref_id}/${model.model_name}`,
-            errorLog: run.error_log
-          });
+          runs.push(site);
         }
       }
       return runs;
@@ -78,21 +62,24 @@ class AlfalfaAPI {
         const model = await this.models.findOne({ _id: run.model });
         let site = await this.sites.findOne({ ref_id: siteRef });
 
+        const site_dict = {
+          id: siteRef,
+          name: model.model_name,
+          status: run.status.toLowerCase(),
+          datetime: "",
+          simType: run.sim_type,
+          uploadTimestamp: run.created,
+          uploadPath: `uploads/${model.ref_id}/${model.model_name}`,
+          errorLog: run.error_log
+        };
+
         if (site) {
-          site = mapHaystack(site);
           const siteHash = await getHash(this.redis, siteRef);
 
-          return {
-            id: run.ref_id,
-            name: site?.dis,
-            status: run.status.toLowerCase(),
-            simType: site.sim_type,
-            datetime: siteHash?.sim_time ?? "",
-            uploadTimestamp: run.created,
-            uploadPath: `uploads/${model.ref_id}/${model.model_name}`,
-            errorLog: run.error_log
-          };
+          site_dict.name = site?.dis;
+          site_dict.datetime = siteHash?.sim_time;
         }
+        return site_dict;
       }
     } catch (e) {
       console.error(e);


### PR DESCRIPTION
Right now alfalfa will not show a site until after it has been processed and information has been extracted from the model. In cases where the model is somehow broken this results in an error being generated but not relayed to the user. This PR removed the requirement of a site entry to be generated in the database. I'm open to critiques of this technique. I do believe that we have a lot of redundancy between Site and Run collections at this current point in time, but now doesn't seem like the time to reconcile that.