### PR TITLE
add ability to disable control points

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -221,16 +221,8 @@ jobs:
       github.ref == 'refs/heads/main' ||
       github.ref == 'refs/heads/develop'
     runs-on: ubuntu-latest
+    needs: [pre-commit, unit-tests, simulation-tests, integration-tests, integration-tests-historian]
     steps:
-      # Only if all other jobs pass.
-      - name: Wait on tests
-        uses: lewagon/wait-on-check-action@v0.2
-        with:
-          ref: ${{ github.ref }}
-          running-workflow-name: "publish" #this job shouldn't wait for itself
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-          wait-interval: 20 # seconds
-
       - name: Checkout code
         uses: actions/checkout@v2
 

--- a/alfalfa_web/server/api.js
+++ b/alfalfa_web/server/api.js
@@ -152,6 +152,10 @@ class AlfalfaAPI {
     if (point.point_type === "OUTPUT") {
       return Promise.reject("Cannot write to an Output point");
     }
+
+    if (value == null) {
+      value = "null";
+    }
     return writePoint(pointId, siteRef, 1, value, this.db, this.redis);
   };
 

--- a/alfalfa_worker/jobs/openstudio/step_run.py
+++ b/alfalfa_worker/jobs/openstudio/step_run.py
@@ -290,11 +290,12 @@ class StepRun(StepRunBase):
 
         for point in self.run.input_points:
             value = point.value
-            if value is None:
-                continue
             index = self.variables.get_input_index(point.ref_id)
             if index == -1:
                 self.logger.error('bad input index for: %s' % point.ref_id)
+            elif value is None:
+                if self.variables.has_enable(point.ref_id):
+                    self.ep.inputs[self.variables.get_input_enable_index(point.ref_id)] = 0
             else:
                 self.ep.inputs[index] = value
                 if self.variables.has_enable(point.ref_id):

--- a/alfalfa_worker/lib/models.py
+++ b/alfalfa_worker/lib/models.py
@@ -436,7 +436,11 @@ class Point(TimestampedDocument):
         value = None
         for entry in write_array:
             if len(entry) > 0:
-                value = float(entry.decode('UTF-8'))
+                string_value = entry.decode('UTF-8')
+                if string_value == "null":
+                    value = None
+                else:
+                    value = float(entry.decode('UTF-8'))
                 break
         return value
 

--- a/tests/integration/test_small_office_osw.py
+++ b/tests/integration/test_small_office_osw.py
@@ -28,3 +28,45 @@ def test_python_environment():
 
     alfalfa.stop(model_id)
     alfalfa.wait(model_id, "complete")
+
+
+@pytest.mark.integration
+def test_io_enable_disable():
+    zip_file_path = prepare_model('small_office')
+    alfalfa = AlfalfaClient(host='http://localhost')
+    site_id = alfalfa.submit(zip_file_path)
+
+    alfalfa.wait(site_id, "ready")
+    start_dt = datetime.datetime(2019, 1, 2, 0, 2, 0)
+    alfalfa.start(
+        site_id,
+        external_clock=True,
+        start_datetime=start_dt,
+        end_datetime=datetime.datetime(2019, 1, 3, 0, 0, 0),
+        timescale=1
+    )
+
+    inputs = alfalfa.get_inputs(site_id)
+    outputs = alfalfa.get_outputs(site_id)
+
+    assert "OfficeSmall HTGSETP_SCH_NO_OPTIMUM" in inputs
+    assert "OfficeSmall HTGSETP_SCH_NO_OPTIMUM" in outputs.keys()
+
+    inputs = {"OfficeSmall HTGSETP_SCH_NO_OPTIMUM": 0}
+    alfalfa.set_inputs(site_id, inputs)
+
+    for _ in range(5):
+        alfalfa.advance(site_id)
+
+        outputs = alfalfa.get_outputs(site_id)
+        assert outputs["OfficeSmall HTGSETP_SCH_NO_OPTIMUM"] == pytest.approx(0)
+
+    inputs = {"OfficeSmall HTGSETP_SCH_NO_OPTIMUM": None}
+    alfalfa.set_inputs(site_id, inputs)
+    alfalfa.advance(site_id)
+
+    outputs = alfalfa.get_outputs(site_id)
+    assert outputs["OfficeSmall HTGSETP_SCH_NO_OPTIMUM"] != pytest.approx(0)
+
+    alfalfa.stop(site_id)
+    alfalfa.wait(site_id, "complete")


### PR DESCRIPTION
This PR allows the user to stop controlling a point by setting it to `None` via the client

fixes #435 