### PR TITLE
Add download site button

### DIFF
--- a/alfalfa_web/components/Sims/Sims.js
+++ b/alfalfa_web/components/Sims/Sims.js
@@ -37,7 +37,10 @@ export const Sims = () => {
 
   const handleDownload = async () => {
     for (const { url } of selectedSims()) {
-      if (url) location.href = url;
+      if (url) {
+        location.href = url;
+        await new Promise((resolve) => setTimeout(resolve, 500));
+      }
     }
   };
 

--- a/alfalfa_web/components/Sites/Sites.js
+++ b/alfalfa_web/components/Sites/Sites.js
@@ -17,7 +17,8 @@ export const Sites = () => {
   const validStates = {
     start: ["ready"],
     stop: ["preprocessing", "starting", "started", "running", "stopping"],
-    remove: ["ready", "complete", "error"]
+    remove: ["ready", "complete", "error"],
+    download: ["read", "complete", "error"]
   };
 
   const fetchSites = async () => {
@@ -52,6 +53,10 @@ export const Sites = () => {
 
   const isRemoveButtonDisabled = () => {
     return !selectedSites().some(({ status }) => validStates.remove.includes(status));
+  };
+
+  const isDownloadButtonDisabled = () => {
+    return !selectedSites().some(({ status }) => validStates.download.includes(status));
   };
 
   const handleOpenErrorDialog = (event, site) => {
@@ -95,6 +100,14 @@ export const Sites = () => {
       .filter(({ status }) => validStates.remove.includes(status))
       .map(async ({ id }) => {
         await ky.delete(`/api/v2/sites/${id}`).json();
+      });
+  };
+
+  const handleDownloadSite = () => {
+    selectedSites()
+      .filter(({ status }) => validStates.download.includes(status))
+      .map(({ id }) => {
+        window.open(`/api/v2/sites/${id}/download`);
       });
   };
 
@@ -175,6 +188,15 @@ export const Sites = () => {
           <Grid item>
             <Button variant="contained" disabled={isRemoveButtonDisabled()} onClick={handleRemoveSite} sx={{ m: 1 }}>
               Remove Test Case
+            </Button>
+          </Grid>
+          <Grid item>
+            <Button
+              variant="contained"
+              disabled={isDownloadButtonDisabled()}
+              onClick={handleDownloadSite}
+              sx={{ m: 1 }}>
+              Download Site
             </Button>
           </Grid>
         </Grid>

--- a/alfalfa_web/components/Sites/Sites.js
+++ b/alfalfa_web/components/Sites/Sites.js
@@ -18,7 +18,7 @@ export const Sites = () => {
     start: ["ready"],
     stop: ["preprocessing", "starting", "started", "running", "stopping"],
     remove: ["ready", "complete", "error"],
-    download: ["read", "complete", "error"]
+    download: ["ready", "complete", "error"]
   };
 
   const fetchSites = async () => {

--- a/alfalfa_web/components/Sites/Sites.js
+++ b/alfalfa_web/components/Sites/Sites.js
@@ -103,12 +103,15 @@ export const Sites = () => {
       });
   };
 
-  const handleDownloadSite = () => {
-    selectedSites()
+  const handleDownloadSite = async () => {
+    const ids = selectedSites()
       .filter(({ status }) => validStates.download.includes(status))
-      .map(({ id }) => {
-        window.open(`/api/v2/sites/${id}/download`);
-      });
+      .map(({ id }) => id);
+
+    for (const id of ids) {
+      location.href = `/api/v2/sites/${id}/download`;
+      await new Promise((resolve) => setTimeout(resolve, 500));
+    }
   };
 
   if (loading) return null;

--- a/alfalfa_web/server/api-v2.js
+++ b/alfalfa_web/server/api-v2.js
@@ -696,6 +696,30 @@ router.post("/sites/:siteId/stop", (req, res) => {
     .catch(() => res.sendStatus(500));
 });
 
+/**
+ * @openapi
+ * /sites/{siteId}/download:
+ *   get:
+ *     operationId: Download site
+ *     description: Download site by redirecting to the S3 tarball url
+ *     tags:
+ *       - Site
+ *     parameters:
+ *       - $ref: '#/components/parameters/SiteID'
+ *     responses:
+ *       302:
+ *         description: Download response
+ *         headers:
+ *           Location:
+ *             schema:
+ *               type: string
+ *               format: url
+ *         content:
+ *           application/octet-stream:
+ *             schema:
+ *               type: string
+ *               format: binary
+ */
 router.get("/sites/:siteId/download", (req, res) => {
   const { siteId } = req.params;
 

--- a/alfalfa_web/server/api-v2.js
+++ b/alfalfa_web/server/api-v2.js
@@ -696,6 +696,27 @@ router.post("/sites/:siteId/stop", (req, res) => {
     .catch(() => res.sendStatus(500));
 });
 
+router.get("/sites/:siteId/download", (req, res) => {
+  const { siteId } = req.params;
+
+  const error = validate(
+    { siteId },
+    {
+      siteId: "required|uuid"
+    }
+  );
+  if (error) return res.status(400).json({ error });
+
+  api
+    .getSiteDownloadPath(siteId)
+    .then((url) => {
+      res.redirect(url);
+    })
+    .catch(() => {
+      res.sendStatus(500);
+    });
+});
+
 /**
  * @openapi
  * /aliases:

--- a/alfalfa_web/server/api.js
+++ b/alfalfa_web/server/api.js
@@ -88,6 +88,21 @@ class AlfalfaAPI {
     }
   };
 
+  getSiteDownloadPath = async (siteRef) => {
+    const signedURL = await getSignedUrl(
+      this.s3,
+      new GetObjectCommand({
+        Bucket: process.env.S3_BUCKET,
+        Key: `run/${siteRef}.tar.gz`,
+        ResponseContentDisposition: `attachment; filename="${siteRef}.tar.gz"`
+      }),
+      {
+        expiresIn: 86400
+      }
+    );
+    return signedURL;
+  };
+
   getSiteTime = async (siteRef) => {
     try {
       return await getHashValue(this.redis, siteRef, "sim_time");


### PR DESCRIPTION
Adds the ability to download a ready, complete or errorred site from the UI.
- Adds `sites/:siteId/download` endpoint which redirects to a signed download url from minio
- Clicking the button opens a new tab to download the file. This allows multiple to be downloaded simultaneously (this does get intercepted by pop up blockers though)
![image](https://github.com/NREL/alfalfa/assets/4641913/676d5910-4ab7-4780-b0ce-c22bf069a07a)

Fixes #446
