### PR TITLE
Convert site electricity sensor from Joules to watts

### DIFF
--- a/alfalfa_worker/jobs/openstudio/lib/alfalfa-lib-gem/lib/utils.rb
+++ b/alfalfa_worker/jobs/openstudio/lib/alfalfa-lib-gem/lib/utils.rb
@@ -28,6 +28,7 @@ module OpenStudio
       # @return [String]
       def create_ems_str(id)
         id = id.gsub(/[\s-]/, '_')
+        id = id.gsub(/[^\w]/, '_')
         id = "_#{id}" if (id =~ /[0-9].*/) == 0
         id
       end

--- a/alfalfa_worker/jobs/openstudio/lib/workflow/measures/alfalfa_site_sensors/measure.rb
+++ b/alfalfa_worker/jobs/openstudio/lib/workflow/measures/alfalfa_site_sensors/measure.rb
@@ -2,6 +2,9 @@ require 'alfalfa'
 # start the measure
 class AlfalfaSiteSensors < OpenStudio::Measure::EnergyPlusMeasure
 
+
+  FuelMeter = Struct.new(:fuel, :adjustment_factor)
+
   include OpenStudio::Alfalfa::EnergyPlusMixin
   # human readable name
   def name
@@ -26,9 +29,13 @@ class AlfalfaSiteSensors < OpenStudio::Measure::EnergyPlusMeasure
     return args
   end
 
-  def create_output_meter(name)
+  def create_output_meter(name, adjustment_factor=1)
     sensor_name = "#{create_ems_str(name)}_sensor"
     output_name = "#{create_ems_str(name)}_output"
+    adjusted_name = "#{create_ems_str(name)}_sensor_adjusted"
+    program_calling_manager_name = "#{create_ems_str(name)}_calling_point"
+    program_name = "#{create_ems_str(name)}_program"
+
     new_meter_string = "
     Output:Meter,
       #{name};
@@ -45,7 +52,32 @@ class AlfalfaSiteSensors < OpenStudio::Measure::EnergyPlusMeasure
     new_sensor_object = OpenStudio::IdfObject.load(new_sensor_string).get
     @workspace.addObject(new_sensor_object)
 
-    create_ems_output_variable(output_name, sensor_name)
+    new_global_variable_string= "
+    EnergyManagementSystem:GlobalVariable,
+    #{adjusted_name};    !- Name
+    "
+
+    new_global_variable_object = OpenStudio::IdfObject.load(new_global_variable_string).get
+    @workspace.addObject(new_global_variable_object)
+
+    new_program_string = "
+    EnergyManagementSystem:Program,
+      #{program_name},           !- Name
+      SET #{adjusted_name} = #{sensor_name}*#{adjustment_factor};
+      "
+    new_program_object = OpenStudio::IdfObject.load(new_program_string).get
+    @workspace.addObject(new_program_object)
+
+    new_calling_manager_string = "
+    EnergyManagementSystem:ProgramCallingManager,
+      #{program_calling_manager_name},          !- Name
+      EndOfZoneTimestepAfterZoneReporting,    !- EnergyPlus Model Calling Point
+      #{program_name};
+      "
+    new_calling_manager_object = OpenStudio::IdfObject.load(new_calling_manager_string).get
+    @workspace.addObject(new_calling_manager_object)
+
+    create_ems_output_variable(output_name, adjusted_name)
   end
 
   # define what happens when the measure is run
@@ -58,11 +90,11 @@ class AlfalfaSiteSensors < OpenStudio::Measure::EnergyPlusMeasure
     end
 
     fuels = [
-      'Electricity'
+      FuelMeter.new('Electricity', 1.0/60)
     ]
 
     fuels.each do |fuel|
-      register_output(create_output_meter("#{fuel}:Facility")).display_name = "Whole Building #{fuel}"
+      register_output(create_output_meter("#{fuel.fuel}:Facility", fuel.adjustment_factor)).display_name = "Whole Building #{fuel.fuel}"
     end
 
     report_inputs_outputs


### PR DESCRIPTION
Add a program to divide site electricity sensor by 60 to convert it from Joules to Watts (Joules/Second).