### PR TITLE
Increase timeout for getting a reply from a run from 6 to 60 seconds

### DIFF
--- a/alfalfa_web/server/api.js
+++ b/alfalfa_web/server/api.js
@@ -229,7 +229,7 @@ class AlfalfaAPI {
     return await this.sendRunMessage(run, "stop");
   };
 
-  sendRunMessage = (run, method, data = null, timeout = 6000, pollingInterval = 100) => {
+  sendRunMessage = (run, method, data = null, timeout = 60000, pollingInterval = 100) => {
     return new Promise(async (resolve, reject) => {
       const message_id = uuidv1();
       await this.pub.publish(run.ref_id, JSON.stringify({ message_id, method, data }));


### PR DESCRIPTION
Ran into some issues in Lab where advance was timing out for a large, complex model. I believe this timeout was supposed to be 60 seconds originally but a 0 was missed. This PR corrects that.