### PR TITLE
Scrape Building Name from EnergyPlus output

### DIFF
--- a/alfalfa_worker/jobs/openstudio/lib/workflow/measures/alfalfa_metadata/measure.rb
+++ b/alfalfa_worker/jobs/openstudio/lib/workflow/measures/alfalfa_metadata/measure.rb
@@ -1,0 +1,54 @@
+# start the measure
+class AlfalfaMetadata < OpenStudio::Measure::EnergyPlusMeasure
+
+  # human readable name
+  def name
+    # Measure name should be the title case of the class name.
+    return 'Alfalfa Metadata'
+  end
+
+  # human readable description
+  def description
+    return 'Generate metadata report for Alfalfa'
+  end
+
+  # human readable description of modeling approach
+  def modeler_description
+    return 'Generate metadata report for Alfalfa'
+  end
+
+  # define the arguments that the user will input
+  def arguments(workspace)
+    args = OpenStudio::Measure::OSArgumentVector.new
+
+    return args
+  end
+
+  # define what happens when the measure is run
+  def run(workspace, runner, user_arguments)
+    super(workspace, runner, user_arguments)
+
+    # use the built-in error checking
+    if !runner.validateUserArguments(arguments(workspace), user_arguments)
+      return false
+    end
+
+    metadata_dict = {}
+
+    buildings = workspace.getObjectsByType('Building'.to_IddObjectType)
+    buildings.each do |building|
+      metadata_dict['building_name'] = building.name.get
+    end
+
+    File.open('./report_metadata.json', 'w') do |f|
+      JSON.dump(metadata_dict, f)
+    end
+
+    runner.registerFinalCondition("Done")
+
+    return true
+  end
+end
+
+# register the measure to be used by the application
+AlfalfaMetadata.new.registerWithApplication

--- a/alfalfa_worker/jobs/openstudio/lib/workflow/measures/alfalfa_metadata/measure.xml
+++ b/alfalfa_worker/jobs/openstudio/lib/workflow/measures/alfalfa_metadata/measure.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0"?>
+<measure>
+  <schema_version>3.1</schema_version>
+  <name>alfalfa_metadata</name>
+  <uid>870213d3-36a2-4da2-9a04-c377a37fd4fe</uid>
+  <version_id>ca01ac21-1a57-4190-a834-5a41dbb63f1a</version_id>
+  <version_modified>2024-05-03T20:06:06Z</version_modified>
+  <xml_checksum>70995EFB</xml_checksum>
+  <class_name>AlfalfaMetadata</class_name>
+  <display_name>Alfalfa Metadata</display_name>
+  <description>Generate metadata report for Alfalfa</description>
+  <modeler_description>Generate metadata report for Alfalfa</modeler_description>
+  <arguments />
+  <outputs />
+  <provenances />
+  <tags>
+    <tag>HVAC.HVAC Controls</tag>
+  </tags>
+  <attributes>
+    <attribute>
+      <name>Measure Type</name>
+      <value>EnergyPlusMeasure</value>
+      <datatype>string</datatype>
+    </attribute>
+  </attributes>
+  <files>
+    <file>
+      <version>
+        <software_program>OpenStudio</software_program>
+        <identifier>3.1.0</identifier>
+        <min_compatible>3.1.0</min_compatible>
+      </version>
+      <filename>measure.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>script</usage_type>
+      <checksum>D2F3FCF2</checksum>
+    </file>
+  </files>
+</measure>


### PR DESCRIPTION
This should have made it into an earlier PR.

It adds a measure which scrapes the Building object's name from the e+ idf and outputs it as a report. The intent is this measure can also be used in the future if we need to extract any other basic information about a model.