### PR TITLE
Check for dependabot before triggering publish action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -249,6 +249,7 @@ jobs:
   publish:
     needs: [pre-commit, unit-tests, simulation-tests, integration-tests, integration-tests-historian]
     runs-on: ubuntu-latest
+    if: github.actor != 'dependabot[bot]'
     steps:
       - name: Checkout code
         uses: actions/checkout@v4


### PR DESCRIPTION
All dependabot PRs are failing because they don't haver permissions to publish a new image to the container registry. This PR will remove that job when the actor running the action is dependabot