### PR TITLE
Allow for running Alfalfa integration tests on non-local deployment

### DIFF
--- a/tests/api/conftest.py
+++ b/tests/api/conftest.py
@@ -8,13 +8,13 @@ from alfalfa_client.alfalfa_client import AlfalfaAPIException
 
 
 @pytest.fixture
-def base_url():
-    return 'http://localhost/api/v2'
+def base_url(alfalfa_host: str):
+    return f'{alfalfa_host}/api/v2'
 
 
 @pytest.fixture
-def alfalfa_client():
-    return AlfalfaClient()
+def alfalfa_client(alfalfa_host: str):
+    return AlfalfaClient(host=alfalfa_host)
 
 
 @pytest.fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -34,3 +34,15 @@ def mock_dispatcher(tmp_path: Path):
     work_dir.mkdir()
     dispatcher = MockDispatcher(work_dir)
     yield dispatcher
+
+
+def pytest_addoption(parser):
+    parser.addoption("--host", action="store", default="http://localhost")
+
+
+@pytest.fixture
+def alfalfa_host(pytestconfig: pytest.Config):
+    alfalfa_host = pytestconfig.getoption("host")
+    if isinstance(alfalfa_host, str):
+        alfalfa_host.rstrip('/')
+    return alfalfa_host

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,7 +1,5 @@
 # Consider factoring this out of the test file
 import os
-import shutil
-import tempfile
 from pathlib import Path
 
 import pytest
@@ -38,8 +36,8 @@ def pytest_generate_tests(metafunc):
 
 
 @pytest.fixture
-def alfalfa():
-    client = AlfalfaClient(host="http://localhost")
+def alfalfa(alfalfa_host: str):
+    client = AlfalfaClient(host=alfalfa_host)
     yield client
 
 
@@ -51,14 +49,6 @@ def ref_id(model_path: Path, alfalfa: AlfalfaClient):
     status = alfalfa.status(ref_id)
     if status == "running":
         alfalfa.stop()
-
-
-def create_zip(model_dir):
-    zip_file_fd, zip_file_path = tempfile.mkstemp(suffix='.zip')
-    zip_file_path = Path(zip_file_path)
-    shutil.make_archive(zip_file_path.parent / zip_file_path.stem, "zip", model_dir)
-
-    return zip_file_path
 
 
 def prepare_model(model_path):

--- a/tests/integration/test_broken_models.py
+++ b/tests/integration/test_broken_models.py
@@ -6,8 +6,7 @@ from alfalfa_client.lib import AlfalfaException, create_zip
 
 
 @pytest.mark.integration
-def test_broken_models(broken_model_path):
-    alfalfa = AlfalfaClient(host='http://localhost')
+def test_broken_models(broken_model_path, alfalfa: AlfalfaClient):
     with pytest.raises(AlfalfaException):
         run_id = alfalfa.submit(str(broken_model_path))
         alfalfa.start(

--- a/tests/integration/test_schedule_override.py
+++ b/tests/integration/test_schedule_override.py
@@ -30,8 +30,7 @@ def test_schedule_point_generation(alfalfa: AlfalfaClient):
 
 
 @pytest.mark.integration
-def test_schedule_override():
-    alfalfa = AlfalfaClient('http://localhost')
+def test_schedule_override(alfalfa: AlfalfaClient):
     site_id = alfalfa.submit(prepare_model('schedule_model'))
 
     alfalfa.start(

--- a/tests/integration/test_small_office_osw.py
+++ b/tests/integration/test_small_office_osw.py
@@ -30,7 +30,6 @@ def test_python_environment(alfalfa: AlfalfaClient):
 
 
 @pytest.mark.integration
-
 def test_io_enable_disable(alfalfa: AlfalfaClient):
     zip_file_path = prepare_model('small_office')
     site_id = alfalfa.submit(zip_file_path)

--- a/tests/integration/test_small_office_osw.py
+++ b/tests/integration/test_small_office_osw.py
@@ -7,9 +7,8 @@ from tests.integration.conftest import prepare_model
 
 
 @pytest.mark.integration
-def test_python_environment():
+def test_python_environment(alfalfa: AlfalfaClient):
     zip_file_path = prepare_model('small_office')
-    alfalfa = AlfalfaClient(host='http://localhost')
     model_id = alfalfa.submit(zip_file_path)
 
     alfalfa.wait(model_id, "ready")
@@ -31,7 +30,8 @@ def test_python_environment():
 
 
 @pytest.mark.integration
-def test_io(alfalfa: AlfalfaClient):
+
+def test_io_enable_disable(alfalfa: AlfalfaClient):
     zip_file_path = prepare_model('small_office')
     site_id = alfalfa.submit(zip_file_path)
 


### PR DESCRIPTION
Adds `--host="<alflalfa_host>"` option to pytest.

This allows for Alfalfa integration and API tests to be run on a remote instance. This is useful for validating a new deployment. After running these tests on on lab instances I discovered a small bug in the Alfalfa deployment helm chart which will be addressed in the next couple days.