### PR TITLE
Re-add pushing the latest tag upon release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -277,6 +277,7 @@ jobs:
             type=semver,pattern={{version}},enable=${{ github.event_name == 'release' }}
             type=semver,pattern={{major}},enable=${{ github.event_name == 'release' }}
             type=semver,pattern={{major}}.{{minor}},enable=${{ github.event_name == 'release' }}
+            type=raw,value=latest,enable=${{ github.event_name == 'release' }}
             type=edge
 
       - name: Expose GitHub Runtime


### PR DESCRIPTION
All the cool kids are getting rid of `latest` tags these days, but I realized that our deployment path is through them, so we should probably keep producing them for the near future.