### PR TITLE
Fix GHCR docker push and document local dev/prod setup

### DIFF
--- a/.env
+++ b/.env
@@ -20,4 +20,4 @@ S3_BUCKET=alfalfa
 S3_URL=http://minio:9000
 S3_URL_EXTERNAL=http://localhost:9000
 VERSION_TAG=latest
-REGISTRY_BASE_URI=ghcr.io/nrel/alfalfa
+REGISTRY_BASE_URI=ghcr.io/natlabrockies/alfalfa

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
 
 env:
   REGISTRY: "ghcr.io"
-  REGISTRY_BASE_URI: ghcr.io/nrel/alfalfa
+  REGISTRY_BASE_URI: ghcr.io/natlabrockies/alfalfa
 
 jobs:
   pre-commit:

--- a/README.md
+++ b/README.md
@@ -50,11 +50,23 @@ docker compose down          # or: docker compose down -v to also remove volumes
 
 ## Docker Images
 
-There are several docker images that are provided for easy deployment using [Alfalfa through Helm](https://github.com/NREL/alfalfa-helm) or other docker services. The images include:
+The Alfalfa docker images are published to the [GitHub Container Registry (GHCR)](https://ghcr.io) under the `natlabrockies` org for easy deployment via Helm or other docker services. The images include:
 
-- [Alfalfa Web](https://hub.docker.com/repository/docker/nrel/alfalfa-web)
-- [Alfalfa Worker](https://hub.docker.com/repository/docker/nrel/alfalfa-worker)
-- [Alfalfa Grafana](https://hub.docker.com/repository/docker/nrel/alfalfa-grafana)
+- [Alfalfa Web](https://github.com/orgs/NatLabRockies/packages/container/package/alfalfa%2Fweb) — `ghcr.io/natlabrockies/alfalfa/web`
+- [Alfalfa Worker](https://github.com/orgs/NatLabRockies/packages/container/package/alfalfa%2Fworker) — `ghcr.io/natlabrockies/alfalfa/worker`
+- [Alfalfa Grafana](https://github.com/orgs/NatLabRockies/packages/container/package/alfalfa%2Fgrafana) — `ghcr.io/natlabrockies/alfalfa/grafana`
+
+Pull an image with:
+
+```bash
+docker pull ghcr.io/natlabrockies/alfalfa/web:latest
+```
+
+If the packages are private, authenticate first with a GitHub personal access token that has the `read:packages` scope:
+
+```bash
+echo $GITHUB_TOKEN | docker login ghcr.io -u <github-username> --password-stdin
+```
 
 ## Python Notebooks
 

--- a/README.md
+++ b/README.md
@@ -4,11 +4,11 @@ Alfalfa is an open source web application forged in the melting pot of Building 
 
 ## User Documentation
 
-Documentation resides in the [GitHub wiki](https://github.com/NREL/alfalfa/wiki)!
+Documentation resides in the [GitHub wiki](https://github.com/NatLabRockies/alfalfa/wiki)!
 
 ## Developer Documentation
 
-We are currently working on increasing our developer documentation. See how to run the tests on the [GitHub wiki](https://github.com/NREL/alfalfa/wiki/Running-Tests). For releasing, see the wiki's [release instructions](https://github.com/NREL/alfalfa/wiki/Release-Instructions).
+We are currently working on increasing our developer documentation. See how to run the tests on the [GitHub wiki](https://github.com/NatLabRockies/alfalfa/wiki/Running-Tests). For releasing, see the wiki's [release instructions](https://github.com/NatLabRockies/alfalfa/wiki/Release-Instructions).
 
 ## Running Alfalfa Locally
 
@@ -70,8 +70,8 @@ echo $GITHUB_TOKEN | docker login ghcr.io -u <github-username> --password-stdin
 
 ## Python Notebooks
 
-An [Alfalfa Python Notebook repository](https://github.com/NREL/alfalfa-notebooks) contains examples on how to interact with Alfalfa.
+An [Alfalfa Python Notebook repository](https://github.com/NatLabRockies/alfalfa-notebooks) contains examples on how to interact with Alfalfa.
 
 ## Alfalfa Client
 
-The Alfalfa Client is a Python library for making API calls to Alfalfa easier. The source code is available on [GitHub](https://github.com/NREL/alfalfa-client) and the package is released through [PyPi](https://pypi.org/project/alfalfa-client/).
+The Alfalfa Client is a Python library for making API calls to Alfalfa easier. The source code is available on [GitHub](https://github.com/NatLabRockies/alfalfa-client) and the package is released through [PyPi](https://pypi.org/project/alfalfa-client/).

--- a/README.md
+++ b/README.md
@@ -10,6 +10,42 @@ Documentation resides in the [GitHub wiki](https://github.com/NREL/alfalfa/wiki)
 
 We are currently working on increasing our developer documentation. See how to run the tests on the [GitHub wiki](https://github.com/NREL/alfalfa/wiki/Running-Tests). For releasing, see the wiki's [release instructions](https://github.com/NREL/alfalfa/wiki/Release-Instructions).
 
+## Running Alfalfa Locally
+
+Alfalfa runs as a Docker Compose stack (web, worker, MongoDB, Redis, and MinIO). Configuration is read from the `.env` file in the repository root. Requires Docker with the Compose plugin.
+
+### Production mode
+
+Builds the optimized web bundle and runs the web service with `node build/index.js`:
+
+```bash
+docker compose up --build
+```
+
+The web application is served at [http://localhost/](http://localhost/) and the API docs at [http://localhost/docs](http://localhost/docs). MinIO is available at [http://localhost:9000](http://localhost:9000).
+
+### Development mode
+
+Mounts `alfalfa_web` and `alfalfa_worker` into the containers and runs them in watch mode so code changes reload automatically (webpack watch for the web, `watchmedo` for the worker):
+
+```bash
+docker compose -f docker-compose.yml -f docker-compose.dev.yml up --build
+```
+
+### Optional historian (InfluxDB + Grafana)
+
+```bash
+HISTORIAN_ENABLE=true docker compose -f docker-compose.yml -f docker-compose.historian.yml up --build
+```
+
+Grafana is served at [http://localhost:3000](http://localhost:3000).
+
+### Stopping
+
+```bash
+docker compose down          # or: docker compose down -v to also remove volumes
+```
+
 # Related Repositories
 
 ## Docker Images

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ docker pull ghcr.io/natlabrockies/alfalfa/web:latest
 If the packages are private, authenticate first with a GitHub personal access token that has the `read:packages` scope:
 
 ```bash
-echo $GITHUB_TOKEN | docker login ghcr.io -u <github-username> --password-stdin
+echo "$GHCR_TOKEN" | docker login ghcr.io -u <github-username> --password-stdin
 ```
 
 ## Python Notebooks

--- a/alfalfa_web/api.yml
+++ b/alfalfa_web/api.yml
@@ -4,7 +4,7 @@ info:
   version: "1.0"
   description: >
     A REST API for controlling virtual buildings.
-    A collaboration between the [Alfalfa](https://github.com/nrel/alfalfa)
+    A collaboration between the [Alfalfa](https://github.com/NatLabRockies/alfalfa)
     and [BOPTEST](https://github.com/ibpsa/project1-boptest) projects.
 tags:
   - name: Point

--- a/alfalfa_web/package-lock.json
+++ b/alfalfa_web/package-lock.json
@@ -30,7 +30,7 @@
         "luxon": "^3.3.0",
         "mongodb": "^6.8.0",
         "morgan": "^1.10.0",
-        "nodehaystack": "github:NREL/nodehaystack#5ffec6835fb63dc2212c07f16e81d191ef05bffb",
+        "nodehaystack": "github:NatLabRockies/nodehaystack#5ffec6835fb63dc2212c07f16e81d191ef05bffb",
         "normalize.css": "^8.0.1",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
@@ -11795,7 +11795,7 @@
     },
     "node_modules/nodehaystack": {
       "version": "2.0.4",
-      "resolved": "git+ssh://git@github.com/NREL/nodehaystack.git#5ffec6835fb63dc2212c07f16e81d191ef05bffb",
+      "resolved": "git+ssh://git@github.com/NatLabRockies/nodehaystack.git#5ffec6835fb63dc2212c07f16e81d191ef05bffb",
       "integrity": "sha512-0VcNXfxLPjlPe83+LumTmORfoXhaCvEJapRt0VxPnODp83u7mmuLEqhDYGCyCtimvT8oPLgOn38pQNfXmr2Cmg==",
       "license": "AFL-3.0",
       "dependencies": {

--- a/alfalfa_web/package.json
+++ b/alfalfa_web/package.json
@@ -42,7 +42,7 @@
     "luxon": "^3.3.0",
     "mongodb": "^6.8.0",
     "morgan": "^1.10.0",
-    "nodehaystack": "github:NREL/nodehaystack#5ffec6835fb63dc2212c07f16e81d191ef05bffb",
+    "nodehaystack": "github:NatLabRockies/nodehaystack#5ffec6835fb63dc2212c07f16e81d191ef05bffb",
     "normalize.css": "^8.0.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",

--- a/alfalfa_worker/Dockerfile
+++ b/alfalfa_worker/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/nrel/alfalfa-dependencies:prepare_080 AS base
+FROM ghcr.io/natlabrockies/alfalfa-dependencies:prepare_080 AS base
 
 ENV HOME=/alfalfa
 

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -1,1 +1,1 @@
-Deployment instructions are maintained in the [wiki](https://github.com/NREL/alfalfa/wiki/Deployment).
+Deployment instructions are maintained in the [wiki](https://github.com/NatLabRockies/alfalfa/wiki/Deployment).

--- a/deploy/k8s-historian.yml
+++ b/deploy/k8s-historian.yml
@@ -222,7 +222,7 @@ items:
                   value: alfalfa
                 - name: INFLUXDB_HOST
                   value: influxdb
-              image: nrel/alfalfa-grafana:develop
+              image: ghcr.io/natlabrockies/alfalfa/grafana:develop
               imagePullPolicy: ""
               name: grafana
               ports:
@@ -502,7 +502,7 @@ items:
                   value: http://minio:9000
                 - name: S3_URL_EXTERNAL
                   value: http://localhost:9000
-              image: nrel/alfalfa-web:develop
+              image: ghcr.io/natlabrockies/alfalfa/web:develop
               imagePullPolicy: ""
               name: web
               ports:
@@ -574,7 +574,7 @@ items:
                   value: alfalfa
                 - name: S3_URL
                   value: http://minio:9000
-              image: nrel/alfalfa-worker:develop
+              image: ghcr.io/natlabrockies/alfalfa/worker:develop
               imagePullPolicy: ""
               name: worker
               resources: {}

--- a/deploy/k8s.yml
+++ b/deploy/k8s.yml
@@ -345,7 +345,7 @@ items:
                   value: http://minio:9000
                 - name: S3_URL_EXTERNAL
                   value: http://localhost:9000
-              image: nrel/alfalfa-web:develop
+              image: ghcr.io/natlabrockies/alfalfa/web:develop
               imagePullPolicy: ""
               name: web
               ports:
@@ -415,7 +415,7 @@ items:
                   value: alfalfa
                 - name: S3_URL
                   value: http://minio:9000
-              image: nrel/alfalfa-worker:develop
+              image: ghcr.io/natlabrockies/alfalfa/worker:develop
               imagePullPolicy: ""
               name: worker
               resources: {}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,15 +3,15 @@ name = "alfalfa"
 version = "1.0.0"
 description = "Alfalfa is a web service that converts building energy models in OpenStudio/EnergyPlus, Spawn of EnergyPlus, or Modelica to interactive virtual buildings."
 authors = [
-    'Kyle Benne <kyle.benne@nrel.gov>',
-    'Anya Petersen <Anya.Petersen@nrel.gov>',
-    'Nicholas Long <nicholas.long@nrel.gov>',
-    'Tobias Shapinsky <tobias.shapinsky@nrel.gov>',
-    'Alex Swindler <alex.swindler@nrel.gov>',
-    'Tim Coleman <tim.coleman@nrel.gov>',
+    'Kyle Benne <kyle.benne@nlr.gov>',
+    'Anya Petersen <Anya.Petersen@nlr.gov>',
+    'Nicholas Long <nicholas.long@nlr.gov>',
+    'Tobias Shapinsky <tobias.shapinsky@nlr.gov>',
+    'Alex Swindler <alex.swindler@nlr.gov>',
+    'Tim Coleman <tim.coleman@nlr.gov>',
     'Cory Mosiman <cory.mosiman12@gmail.com>',
-    'Brian Ball <brian.ball@nrel.gov>',
-    'Willy Bernal <willy.bernalheredia@nrel.gov>',
+    'Brian Ball <brian.ball@nlr.gov>',
+    'Willy Bernal <willy.bernalheredia@nlr.gov>',
 ]
 package-mode = false
 
@@ -34,7 +34,7 @@ influxdb = "^5.3.1"
 # and calling poetry update. I have had to completely remove my venv and reinstall in order
 # to get the latest updates.
 alfalfa-client = "1.0.0"
-# alfalfa-client = { git = "https://github.com/NREL/alfalfa-client.git", branch = "enhance_file_operations" }
+# alfalfa-client = { git = "https://github.com/NatLabRockies/alfalfa-client.git", branch = "enhance_file_operations" }
 autopep8 = "~2.0"
 pre-commit = "~2.21"
 pytest = "~7.2"

--- a/setup.cfg
+++ b/setup.cfg
@@ -6,7 +6,7 @@
 name = alfalfa-worker
 description = Alfalfa Project
 author = Kyle Benne
-author-email = kyle.benne@nrel.gov
+author-email = kyle.benne@nlr.gov
 license = BSD
 long-description = file: README.md
 long-description-content-type = text/x-rst; charset=UTF-8

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,3 +1,3 @@
 # Tests
 
-Testing specifics are maintained on the [wiki](https://github.com/NREL/alfalfa/wiki/Running-Tests).
+Testing specifics are maintained on the [wiki](https://github.com/NatLabRockies/alfalfa/wiki/Running-Tests).


### PR DESCRIPTION
## Why

CI's publish job was failing: `REGISTRY_BASE_URI` in `ci.yml` and `.env` still pointed at `ghcr.io/nrel/alfalfa`, but the publish job authenticates to GHCR with `GITHUB_TOKEN` scoped to the `NatLabRockies` org, so pushing to the `nrel` namespace was denied. The worker `Dockerfile` had the same stale `nrel` base image path. On top of that, the README, deploy docs, and test docs still linked to the old `NREL/alfalfa` repo/wiki, and there was no accurate local dev/prod quick-start for new contributors.

## What changed

- **CI docker push fix** (`.github/workflows/ci.yml`, `.env`, `alfalfa_worker/Dockerfile`): point `REGISTRY_BASE_URI` and the worker base image to `ghcr.io/natlabrockies/*`, matching the repo org. This unblocks the "Build and publish Docker images" job.
- **README local quick-start**: added a "Running Alfalfa Locally" section with verified Docker Compose commands for production mode, development mode, the optional historian (InfluxDB + Grafana), and teardown.
- **README registry docs**: replaced the old Docker Hub image links (`nrel/alfalfa-*`) with the GHCR packages under `natlabrockies`, plus a `docker pull` example and a `docker login ghcr.io` note for private packages.
- **NREL → NatLabRockies reference cleanup**: updated remaining `github.com/NREL/...` links (README, `deploy/README.md`, `tests/README.md`, `alfalfa_web/api.yml`) and package metadata (`alfalfa_web/package.json`/`package-lock.json` `nodehaystack` dependency source, `pyproject.toml` author emails/alfalfa-client git ref, `setup.cfg` author email) to point at `nlr.gov`/`NatLabRockies` instead of `nrel.gov`/`NREL`.
- **K8s deploy manifest fix** (`deploy/k8s.yml`, `deploy/k8s-historian.yml`): updated the hardcoded `nrel/alfalfa-{web,worker,grafana}` Docker Hub image references to the published `ghcr.io/natlabrockies/alfalfa/*` images, matching the registry docs above.

## Validation

Both stacks were brought up locally and confirmed healthy: web serves HTTP 200 on `/` and `/docs`, and the worker dispatcher connects to MongoDB, Redis, and MinIO in both dev and production modes.

## Notes for reviewers

The Compose files still pull third-party base images (mongo, redis, minio, grafana, influxdb, node) implicitly from Docker Hub. Those are upstream images, not Alfalfa's, so they were intentionally left as-is; only references to Alfalfa's own published images/repo were moved to GHCR/NatLabRockies.

