### PR TITLE
Finish NREL → NatLabRockies / nlr.gov rebrand references

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
 
 env:
   REGISTRY: "ghcr.io"
-  REGISTRY_BASE_URI: ghcr.io/nrel/pacer-webservice
+  REGISTRY_BASE_URI: ghcr.io/natlabrockies/pacer-webservice
 
 jobs:
   pre-commit:

--- a/README.md
+++ b/README.md
@@ -4,26 +4,26 @@ Alfalfa is an open source web application forged in the melting pot of Building 
 
 ## User Documentation
 
-Documentation resides in the [GitHub wiki](https://github.com/NREL/alfalfa/wiki)!
+Documentation resides in the [GitHub wiki](https://github.com/NatLabRockies/alfalfa/wiki)!
 
 ## Developer Documentation
 
-We are currently working on increasing our developer documentation. See how to run the tests on the [GitHub wiki](https://github.com/NREL/alfalfa/wiki/Running-Tests). For releasing, see the wiki's [release instructions](https://github.com/NREL/alfalfa/wiki/Release-Instructions).
+We are currently working on increasing our developer documentation. See how to run the tests on the [GitHub wiki](https://github.com/NatLabRockies/alfalfa/wiki/Running-Tests). For releasing, see the wiki's [release instructions](https://github.com/NatLabRockies/alfalfa/wiki/Release-Instructions).
 
 # Related Repositories
 
 ## Docker Images
 
-There are several docker images that are provided for easy deployment using [Alfalfa through Helm](https://github.com/NREL/alfalfa-helm) or other docker services. The images include:
+There are several docker images that are provided for easy deployment using [Alfalfa through Helm](https://github.com/NatLabRockies/alfalfa-helm) or other docker services. The images are published to the GitHub Container Registry under `ghcr.io/natlabrockies/pacer-webservice`:
 
-- [Alfalfa Web](https://hub.docker.com/repository/docker/nrel/alfalfa-web)
-- [Alfalfa Worker](https://hub.docker.com/repository/docker/nrel/alfalfa-worker)
-- [Alfalfa Grafana](https://hub.docker.com/repository/docker/nrel/alfalfa-grafana)
+- Alfalfa Web: `ghcr.io/natlabrockies/pacer-webservice/web`
+- Alfalfa Worker: `ghcr.io/natlabrockies/pacer-webservice/worker`
+- Alfalfa Grafana: `ghcr.io/natlabrockies/pacer-webservice/grafana`
 
 ## Python Notebooks
 
-An [Alfalfa Python Notebook repository](https://github.com/NREL/alfalfa-notebooks) contains examples on how to interact with Alfalfa.
+An [Alfalfa Python Notebook repository](https://github.com/NatLabRockies/alfalfa-notebooks) contains examples on how to interact with Alfalfa.
 
 ## Alfalfa Client
 
-The Alfalfa Client is a Python library for making API calls to Alfalfa easier. The source code is available on [GitHub](https://github.com/NREL/alfalfa-client) and the package is released through [PyPi](https://pypi.org/project/alfalfa-client/).
+The Alfalfa Client is a Python library for making API calls to Alfalfa easier. The source code is available on [GitHub](https://github.com/NatLabRockies/alfalfa-client) and the package is released through [PyPi](https://pypi.org/project/alfalfa-client/).

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -1,1 +1,1 @@
-Deployment instructions are maintained in the [wiki](https://github.com/NREL/alfalfa/wiki/Deployment).
+Deployment instructions are maintained in the [wiki](https://github.com/NatLabRockies/alfalfa/wiki/Deployment).

--- a/pacer_web/api.yml
+++ b/pacer_web/api.yml
@@ -4,7 +4,7 @@ info:
   version: "1.0"
   description: >
     A REST API for controlling virtual buildings.
-    A collaboration between the [PACER](https://github.com/nrel/pacer)
+    A collaboration between the [PACER](https://github.com/NatLabRockies/alfalfa)
     and [BOPTEST](https://github.com/ibpsa/project1-boptest) projects.
 tags:
   - name: Point

--- a/pacer_web/package-lock.json
+++ b/pacer_web/package-lock.json
@@ -30,7 +30,7 @@
         "luxon": "^3.3.0",
         "mongodb": "^6.8.0",
         "morgan": "^1.10.0",
-        "nodehaystack": "github:NREL/nodehaystack#5ffec6835fb63dc2212c07f16e81d191ef05bffb",
+        "nodehaystack": "github:NatLabRockies/nodehaystack#5ffec6835fb63dc2212c07f16e81d191ef05bffb",
         "normalize.css": "^8.0.1",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
@@ -11795,7 +11795,7 @@
     },
     "node_modules/nodehaystack": {
       "version": "2.0.4",
-      "resolved": "git+ssh://git@github.com/NREL/nodehaystack.git#5ffec6835fb63dc2212c07f16e81d191ef05bffb",
+      "resolved": "git+ssh://git@github.com/NatLabRockies/nodehaystack.git#5ffec6835fb63dc2212c07f16e81d191ef05bffb",
       "integrity": "sha512-0VcNXfxLPjlPe83+LumTmORfoXhaCvEJapRt0VxPnODp83u7mmuLEqhDYGCyCtimvT8oPLgOn38pQNfXmr2Cmg==",
       "license": "AFL-3.0",
       "dependencies": {

--- a/pacer_web/package.json
+++ b/pacer_web/package.json
@@ -42,7 +42,7 @@
     "luxon": "^3.3.0",
     "mongodb": "^6.8.0",
     "morgan": "^1.10.0",
-    "nodehaystack": "github:NREL/nodehaystack#5ffec6835fb63dc2212c07f16e81d191ef05bffb",
+    "nodehaystack": "github:NatLabRockies/nodehaystack#5ffec6835fb63dc2212c07f16e81d191ef05bffb",
     "normalize.css": "^8.0.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,15 +3,15 @@ name = "pacer"
 version = "1.0.0"
 description = "Pacer web service converts building energy models in OpenStudio/EnergyPlus, Spawn of EnergyPlus, or Modelica to interactive virtual buildings."
 authors = [
-  'Kyle Benne <kyle.benne@nrel.gov>',
-  'Anya Petersen <Anya.Petersen@nrel.gov>',
-  'Nicholas Long <nicholas.long@nrel.gov>',
-  'Tobias Shapinsky <tobias.shapinsky@nrel.gov>',
-  'Alex Swindler <alex.swindler@nrel.gov>',
-  'Tim Coleman <tim.coleman@nrel.gov>',
+  'Kyle Benne <kyle.benne@nlr.gov>',
+  'Anya Petersen <Anya.Petersen@nlr.gov>',
+  'Nicholas Long <nicholas.long@nlr.gov>',
+  'Tobias Shapinsky <tobias.shapinsky@nlr.gov>',
+  'Alex Swindler <alex.swindler@nlr.gov>',
+  'Tim Coleman <tim.coleman@nlr.gov>',
   'Cory Mosiman <cory.mosiman12@gmail.com>',
-  'Brian Ball <brian.ball@nrel.gov>',
-  'Willy Bernal <willy.bernalheredia@nrel.gov>',
+  'Brian Ball <brian.ball@nlr.gov>',
+  'Willy Bernal <willy.bernalheredia@nlr.gov>',
 ]
 package-mode = false
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ influxdb = "^5.3.1"
 # and calling poetry update. I have had to completely remove my venv and reinstall in order
 # to get the latest updates.
 alfalfa-client = "1.0.0"
-# alfalfa-client = { git = "https://github.com/NREL/alfalfa-client.git", branch = "enhance_file_operations" }
+# alfalfa-client = { git = "https://github.com/NatLabRockies/alfalfa-client.git", branch = "enhance_file_operations" }
 autopep8 = "~2.0"
 pre-commit = "~2.21"
 pytest = "~7.2"

--- a/setup.cfg
+++ b/setup.cfg
@@ -6,7 +6,7 @@
 name = pacer-worker
 description =PACER Webservice Project
 author = Kyle Benne
-author-email = kyle.benne@nrel.gov
+author-email = kyle.benne@nlr.gov
 license = BSD
 long-description = file: README.md
 long-description-content-type = text/x-rst; charset=UTF-8

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,3 +1,3 @@
 # Tests
 
-Testing specifics are maintained on the [wiki](https://github.com/NREL/alfalfa/wiki/Running-Tests).
+Testing specifics are maintained on the [wiki](https://github.com/NatLabRockies/alfalfa/wiki/Running-Tests).


### PR DESCRIPTION
Completes the branding sweep on top of the Alfalfa → PACER rename. Targets `pacer_rename`.

## Author emails (`nrel.gov` → `nlr.gov`)
- `pyproject.toml` — 8 author emails
- `setup.cfg` — `author-email`
- Left Cory Mosiman's personal `@gmail.com` and `AUTHORS.md` (GitHub handles) unchanged

## GitHub org URLs (`NREL`/`nrel` → `NatLabRockies`)
Repo paths kept as `alfalfa`/`alfalfa-helm`/`alfalfa-notebooks`/`alfalfa-client` (repos were transferred but not yet renamed to `pacer`; all verified to exist under `NatLabRockies`).
- `README.md` — wiki, `alfalfa-helm`, notebooks, client links
- `deploy/README.md`, `tests/README.md` — wiki links
- `pyproject.toml` — commented-out `alfalfa-client.git` git URL
- `pacer_web/api.yml` — `github.com/nrel/pacer` (nonexistent) → the live `NatLabRockies/alfalfa` repo
- `pacer_web/package.json` + `package-lock.json` — `nodehaystack` dependency `github:NREL/...` → `github:NatLabRockies/...` (same commit SHA)

## Registry / Docker
- `.github/workflows/ci.yml` — fixed `REGISTRY_BASE_URI` `ghcr.io/nrel/pacer-webservice` → `ghcr.io/natlabrockies/pacer-webservice` (was inconsistent with `.env`)
- `README.md` Docker Images — the `natlabrockies` Docker Hub namespace doesn't exist (404), so repointed the bullets to the real images at `ghcr.io/natlabrockies/pacer-webservice/{web,worker,grafana}`

## Deliberately left as-is (not branding)
- `CHANGELOG.md` history and `.git-blame-ignore-revs`
- Weather `.epw` files and `cosim.idf` — "NREL" is data provenance in the file format
- `measure.rb` link to `nrel.github.io/OpenStudio-user-documentation` (legit external OpenStudio docs)

After this, `nrel`/`NREL` no longer appears outside the files listed above.

> Note: "Alfalfa" prose in the main README is intentionally **not** renamed to PACER here — that's a separate, larger decision and `pacer_rename` deliberately left the README prose alone.