### PR TITLE
Rename client references to pacer-client and NatLabRockies org

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,4 +26,4 @@ An [Alfalfa Python Notebook repository](https://github.com/NREL/alfalfa-notebook
 
 ## Alfalfa Client
 
-The Alfalfa Client is a Python library for making API calls to Alfalfa easier. The source code is available on [GitHub](https://github.com/NatLabRockies/alfalfa-client) and the package is released through [PyPi](https://pypi.org/project/alfalfa-client/).
+The Alfalfa Client is a Python library for making API calls to Alfalfa easier. The source code is available on [GitHub](https://github.com/NatLabRockies/alfalfa-client) and the package is released through [PyPi](https://pypi.org/project/pacer-client/).

--- a/README.md
+++ b/README.md
@@ -26,4 +26,4 @@ An [Alfalfa Python Notebook repository](https://github.com/NREL/alfalfa-notebook
 
 ## Alfalfa Client
 
-The Alfalfa Client is a Python library for making API calls to Alfalfa easier. The source code is available on [GitHub](https://github.com/NREL/alfalfa-client) and the package is released through [PyPi](https://pypi.org/project/alfalfa-client/).
+The Alfalfa Client is a Python library for making API calls to Alfalfa easier. The source code is available on [GitHub](https://github.com/NatLabRockies/alfalfa-client) and the package is released through [PyPi](https://pypi.org/project/alfalfa-client/).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ influxdb = "^5.3.1"
 # and calling poetry update. I have had to completely remove my venv and reinstall in order
 # to get the latest updates.
 alfalfa-client = "1.0.0"
-# alfalfa-client = { git = "https://github.com/NREL/alfalfa-client.git", branch = "enhance_file_operations" }
+# alfalfa-client = { git = "git@github.com:NatLabRockies/alfalfa-client.git", branch = "enhance_file_operations" }
 autopep8 = "~2.0"
 pre-commit = "~2.21"
 pytest = "~7.2"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,8 +33,8 @@ influxdb = "^5.3.1"
 # required for tests to pass right now. There are often issues when pinning to a branch
 # and calling poetry update. I have had to completely remove my venv and reinstall in order
 # to get the latest updates.
-alfalfa-client = "1.0.0"
-# alfalfa-client = { git = "git@github.com:NatLabRockies/alfalfa-client.git", branch = "enhance_file_operations" }
+pacer-client = "1.0.0"
+# pacer-client = { git = "git@github.com:NatLabRockies/alfalfa-client.git", branch = "enhance_file_operations" }
 autopep8 = "~2.0"
 pre-commit = "~2.21"
 pytest = "~7.2"

--- a/tests/api/conftest.py
+++ b/tests/api/conftest.py
@@ -3,8 +3,8 @@ from datetime import datetime
 from pathlib import Path
 
 import pytest
-from alfalfa_client import AlfalfaClient
-from alfalfa_client.alfalfa_client import AlfalfaAPIException
+from pacer_client import PacerClient
+from pacer_client.pacer_client import PacerAPIException
 
 
 @pytest.fixture
@@ -14,7 +14,7 @@ def base_url(pacer_host: str):
 
 @pytest.fixture
 def alfalfa_client(pacer_host: str):
-    return AlfalfaClient(host=pacer_host)
+    return PacerClient(host=pacer_host)
 
 
 @pytest.fixture
@@ -23,12 +23,12 @@ def model_path():
 
 
 @pytest.fixture
-def model_id(alfalfa_client: AlfalfaClient, model_path):
+def model_id(alfalfa_client: PacerClient, model_path):
     return alfalfa_client.upload_model(model_path)
 
 
 @pytest.fixture
-def run_id(alfalfa_client: AlfalfaClient, model_path):
+def run_id(alfalfa_client: PacerClient, model_path):
     run_id = alfalfa_client.submit(model_path)
     yield run_id
     try:
@@ -39,12 +39,12 @@ def run_id(alfalfa_client: AlfalfaClient, model_path):
             "READY",
         ]:
             alfalfa_client.stop(run_id)
-    except AlfalfaAPIException:
+    except PacerAPIException:
         pass
 
 
 @pytest.fixture
-def started_run_id(alfalfa_client: AlfalfaClient, run_id):
+def started_run_id(alfalfa_client: PacerClient, run_id):
     alfalfa_client.start(
         run_id,
         datetime(2020, 1, 1, 0, 0),

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -3,7 +3,7 @@ import os
 from pathlib import Path
 
 import pytest
-from alfalfa_client.alfalfa_client import AlfalfaClient
+from pacer_client.pacer_client import PacerClient
 
 
 def pytest_generate_tests(metafunc):
@@ -32,12 +32,12 @@ def pytest_generate_tests(metafunc):
 
 @pytest.fixture
 def client(pacer_host: str):
-    client = AlfalfaClient(host=pacer_host)
+    client = PacerClient(host=pacer_host)
     yield client
 
 
 @pytest.fixture
-def ref_id(model_path: Path, client: AlfalfaClient):
+def ref_id(model_path: Path, client: PacerClient):
     ref_id = client.submit(model_path)
     yield ref_id
 

--- a/tests/integration/test_basic_operations.py
+++ b/tests/integration/test_basic_operations.py
@@ -1,11 +1,11 @@
 from datetime import datetime, timedelta
 
 import pytest
-from alfalfa_client.alfalfa_client import AlfalfaClient, RunID
+from pacer_client.pacer_client import PacerClient, RunID
 
 
 @pytest.mark.integration
-def test_simple_internal_clock(client: AlfalfaClient, ref_id: RunID):
+def test_simple_internal_clock(client: PacerClient, ref_id: RunID):
     client.wait(ref_id, "ready")
 
     end_datetime = datetime(2019, 1, 2, 0, 2, 0)
@@ -29,7 +29,7 @@ def test_simple_internal_clock(client: AlfalfaClient, ref_id: RunID):
 
 
 @pytest.mark.integration
-def test_simple_external_clock(client: AlfalfaClient, ref_id: RunID):
+def test_simple_external_clock(client: PacerClient, ref_id: RunID):
     client.wait(ref_id, "ready")
     start_dt = datetime(2019, 1, 2, 0, 0, 0)
     client.start(
@@ -60,6 +60,6 @@ def test_simple_external_clock(client: AlfalfaClient, ref_id: RunID):
 
 
 @pytest.mark.integration
-def test_alias(client: AlfalfaClient, ref_id: RunID):
+def test_alias(client: PacerClient, ref_id: RunID):
     client.set_alias("test", ref_id)
     assert client.get_alias("test") == ref_id

--- a/tests/integration/test_broken_models.py
+++ b/tests/integration/test_broken_models.py
@@ -1,13 +1,13 @@
 import datetime
 
 import pytest
-from alfalfa_client.alfalfa_client import AlfalfaClient
-from alfalfa_client.lib import AlfalfaException, create_zip
+from pacer_client.pacer_client import PacerClient
+from pacer_client.lib import PacerException, create_zip
 
 
 @pytest.mark.integration
-def test_broken_models(broken_model_path, client: AlfalfaClient):
-    with pytest.raises(AlfalfaException):
+def test_broken_models(broken_model_path, client: PacerClient):
+    with pytest.raises(PacerException):
         run_id = client.submit(str(broken_model_path))
         client.start(
             run_id,
@@ -23,14 +23,14 @@ def test_broken_models(broken_model_path, client: AlfalfaClient):
 
 
 @pytest.mark.integration
-def test_broken_python_models(client: AlfalfaClient, broken_workflow_name):
+def test_broken_python_models(client: PacerClient, broken_workflow_name):
     model_zip_path = create_zip(
         "tests/integration/broken_models/small_office/measures",
         "tests/integration/broken_models/small_office/weather",
         "tests/integration/broken_models/small_office/small_office.osm",
         f"tests/integration/broken_models/small_office/{broken_workflow_name}",
     )
-    with pytest.raises(AlfalfaException):
+    with pytest.raises(PacerException):
         run_id = client.submit(model_zip_path)
         client.start(
             run_id,

--- a/tests/integration/test_broken_models.py
+++ b/tests/integration/test_broken_models.py
@@ -1,8 +1,8 @@
 import datetime
 
 import pytest
-from pacer_client.pacer_client import PacerClient
 from pacer_client.lib import PacerException, create_zip
+from pacer_client.pacer_client import PacerClient
 
 
 @pytest.mark.integration

--- a/tests/integration/test_modelica.py
+++ b/tests/integration/test_modelica.py
@@ -1,13 +1,13 @@
 from datetime import datetime
 
 import pytest
-from alfalfa_client import AlfalfaClient
+from pacer_client import PacerClient
 
 from tests.integration.conftest import prepare_model
 
 
 @pytest.mark.integration
-def test_modelica_model(client: AlfalfaClient):
+def test_modelica_model(client: PacerClient):
     run_id = client.submit(prepare_model("wrapped.fmu"))
 
     client.start(

--- a/tests/integration/test_schedule_override.py
+++ b/tests/integration/test_schedule_override.py
@@ -1,13 +1,13 @@
 from datetime import datetime
 
 import pytest
-from alfalfa_client.alfalfa_client import AlfalfaClient
+from pacer_client.pacer_client import PacerClient
 
 from tests.integration.conftest import prepare_model
 
 
 @pytest.mark.integration
-def test_schedule_point_generation(client: AlfalfaClient):
+def test_schedule_point_generation(client: PacerClient):
     run_id = client.submit(prepare_model("schedule_model"))
 
     client.start(run_id, datetime(2020, 1, 1, 0, 0), datetime(2020, 1, 1, 0, 1))
@@ -36,7 +36,7 @@ def test_schedule_point_generation(client: AlfalfaClient):
 
 
 @pytest.mark.integration
-def test_schedule_override(client: AlfalfaClient):
+def test_schedule_override(client: PacerClient):
     site_id = client.submit(prepare_model("schedule_model"))
 
     client.start(

--- a/tests/integration/test_small_office_osw.py
+++ b/tests/integration/test_small_office_osw.py
@@ -1,13 +1,13 @@
 import datetime
 
 import pytest
-from alfalfa_client.alfalfa_client import AlfalfaClient
+from pacer_client.pacer_client import PacerClient
 
 from tests.integration.conftest import prepare_model
 
 
 @pytest.mark.integration
-def test_python_environment(client: AlfalfaClient):
+def test_python_environment(client: PacerClient):
     zip_file_path = prepare_model("small_office")
     model_id = client.submit(zip_file_path)
 
@@ -30,7 +30,7 @@ def test_python_environment(client: AlfalfaClient):
 
 
 @pytest.mark.integration
-def test_io_enable_disable(client: AlfalfaClient):
+def test_io_enable_disable(client: PacerClient):
     zip_file_path = prepare_model("small_office")
     site_id = client.submit(zip_file_path)
 

--- a/tests/integration/test_worker_scale.py
+++ b/tests/integration/test_worker_scale.py
@@ -3,8 +3,8 @@ from math import ceil
 from time import sleep
 
 import pytest
-from alfalfa_client.alfalfa_client import AlfalfaClient
-from alfalfa_client.lib import AlfalfaException
+from pacer_client.pacer_client import PacerClient
+from pacer_client.lib import PacerException
 
 from tests.integration.conftest import prepare_model
 
@@ -13,7 +13,7 @@ WORKER_COUNT = 2
 
 
 @pytest.fixture
-def scale_models(client: AlfalfaClient):
+def scale_models(client: PacerClient):
 
     MODEL_PATHS = []
     MODEL_PATHS.append("wrapped.fmu")
@@ -40,7 +40,7 @@ def scale_models(client: AlfalfaClient):
             status = client.status(model_id)
             if status == "running":
                 stop_ids.append(model_id)
-        except AlfalfaException as e:
+        except PacerException as e:
             exception = e
     if len(stop_ids) > 0:
         client.stop(stop_ids)
@@ -49,7 +49,7 @@ def scale_models(client: AlfalfaClient):
 
 
 @pytest.mark.scale
-def test_multiple_workers_simple_external_clock(scale_models, client: AlfalfaClient):
+def test_multiple_workers_simple_external_clock(scale_models, client: PacerClient):
 
     for model_ids in scale_models:
         start_time = datetime(2019, 1, 2, 0, 0, 0)
@@ -75,7 +75,7 @@ def test_multiple_workers_simple_external_clock(scale_models, client: AlfalfaCli
 
 
 @pytest.mark.scale
-def test_multiple_workers_simple_internal_clock(scale_models, client: AlfalfaClient):
+def test_multiple_workers_simple_internal_clock(scale_models, client: PacerClient):
 
     for model_ids in scale_models:
         start_time = datetime(2019, 1, 2, 0, 0, 0)

--- a/tests/integration/test_worker_scale.py
+++ b/tests/integration/test_worker_scale.py
@@ -3,8 +3,8 @@ from math import ceil
 from time import sleep
 
 import pytest
-from pacer_client.pacer_client import PacerClient
 from pacer_client.lib import PacerException
+from pacer_client.pacer_client import PacerClient
 
 from tests.integration.conftest import prepare_model
 


### PR DESCRIPTION
## Why

As part of the PACER rename, the client library is moving to the `NatLabRockies` org and will be republished on PyPI as `pacer-client`. This repo still pointed its client references at the old `NREL/alfalfa-client`.

## What

- Update the dev dependency and README to `pacer-client`, and point the commented dev git template + README source link at `NatLabRockies/alfalfa-client`.
- Rename the client imports/usages in the test suite from `alfalfa_client`/`AlfalfaClient` to `pacer_client`/`PacerClient` (plus `PacerException` / `PacerAPIException`).

## Heads-up for reviewers

- This is stacked on `pacer_rename` and targets that branch, not `develop`.
- `poetry.lock` is intentionally left unchanged. It cannot be re-locked until `pacer-client` is actually published to PyPI, so client-dependent installs/tests will fail until then (expected).
- The GitHub repo keeps its name `NatLabRockies/alfalfa-client`; only the PyPI package name becomes `pacer-client`.
- The local `alfalfa_client` pytest fixture name is preserved (matches the existing `pacer_rename` convention).