### PR TITLE
Add Dependabot config: weekly grouped updates, limit 10

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,65 @@
+version: 2
+updates:
+  # Python dependencies (poetry, pyproject.toml/poetry.lock at repo root)
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    groups:
+      python-dependencies:
+        patterns:
+          - "*"
+
+  # JavaScript dependencies for the web app
+  - package-ecosystem: "npm"
+    directory: "/alfalfa_web"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    groups:
+      npm-dependencies:
+        patterns:
+          - "*"
+
+  # Docker base images
+  - package-ecosystem: "docker"
+    directory: "/alfalfa_web"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    groups:
+      docker-dependencies:
+        patterns:
+          - "*"
+
+  - package-ecosystem: "docker"
+    directory: "/alfalfa_worker"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    groups:
+      docker-dependencies:
+        patterns:
+          - "*"
+
+  - package-ecosystem: "docker"
+    directory: "/grafana"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    groups:
+      docker-dependencies:
+        patterns:
+          - "*"
+
+  # GitHub Actions used in workflows
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    groups:
+      github-actions-dependencies:
+        patterns:
+          - "*"


### PR DESCRIPTION
## Summary

No `.github/dependabot.yml` existed, so version updates ran with GitHub's defaults: daily-ish/ungrouped-by-default behavior and an open-PR limit of 5 per ecosystem. This adds an explicit config for every ecosystem currently in the repo:

- **pip** (`/`, poetry)
- **npm** (`/alfalfa_web`)
- **docker** (`/alfalfa_web`, `/alfalfa_worker`, `/grafana`)
- **github-actions** (`/`)

Each is set to:
- `schedule.interval: weekly`
- `groups` with a single "all dependencies" group per ecosystem/directory, so Dependabot opens one combined PR per run instead of one PR per dependency
- `open-pull-requests-limit: 10` (up from the default of 5), so more grouped updates can be open at once

## Validation
- YAML parsed successfully with PyYAML
- `pre-commit run --files .github/dependabot.yml` passes (check-yaml, prettier, etc.)

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>