### PR TITLE
Fix Modelica advance() writing entire output dict to each point instead of its scalar value

### DIFF
--- a/alfalfa_worker/jobs/modelica/step_run.py
+++ b/alfalfa_worker/jobs/modelica/step_run.py
@@ -100,7 +100,7 @@ class StepRun(StepRunBase):
         influx_points = []
         for point in self.run.output_points:
             value = y_output[point.name]
-            point.value = y_output
+            point.value = value
 
             if self.options.historian_enabled:
                 influx_points.append({"fields":

--- a/tests/integration/test_modelica.py
+++ b/tests/integration/test_modelica.py
@@ -142,4 +142,11 @@ def test_modelica_model(alfalfa: AlfalfaClient):
     for _ in range(5):
         alfalfa.advance(run_id)
 
+    # Regression test: advance() must write each point's own scalar value,
+    # not the entire output dict (see step_run.py StepRun.advance). A
+    # regression here causes every output point to read back as None/NaN.
+    output_values = alfalfa.get_outputs(run_id)
+    assert output_values["chi_reaTSup_y"] is not None
+    assert isinstance(output_values["chi_reaTSup_y"], (int, float))
+
     alfalfa.stop(run_id)


### PR DESCRIPTION
## Problem

In `StepRun.advance()` (`alfalfa_worker/jobs/modelica/step_run.py`), each output point was assigned the **entire** `y_output` dict returned by `tc.advance(u)` instead of that point's own scalar value:

```python
for point in self.run.output_points:
    value = y_output[point.name]
    point.value = y_output   # bug: should be `value`
```

`Point.value`'s setter (`alfalfa_worker/lib/models.py`) interpolates the assigned object into a Redis string via `f'n:{value}'`, so every output point ends up storing a stringified Python dict in Redis instead of its own number. The web API's `readOutputPoint()` (`alfalfa_web/server/api.js`) then calls `parseFloat()` on that string, which returns `NaN`, and `NaN` serializes to `null` in the JSON response.

**Net effect:** every Modelica/FMU run's output points always read back as `null` via `GET/POST .../points/values`, even though `sim_time` advances correctly and the FMU is stepping as expected. This affects any Modelica FMU site (verified with a Buildings-library FMU compiled outside this repo).

## Fix

One-line fix: assign the extracted scalar `value` to `point.value`, not the whole `y_output` dict.

## Testing

- Reproduced the bug against a locally built `worker` image on this branch's parent (`develop`) using a standalone FMU: confirmed `points/values` returned `null` for every output despite `sim_time` correctly advancing.
- Applied the fix, rebuilt, and confirmed real numeric values are now returned (e.g. `{"outlet.forward.T": 304.58..., "outlet.m_flow": 0.5}`).
- Ran a full multi-timestep coupled two-FMU simulation end-to-end against the fixed build with sensible, physically-converging output values throughout.
- Added a regression assertion to `tests/integration/test_modelica.py` asserting a real (non-null, numeric) output value after advancing.
- `pre-commit run` passes on both changed files.

Discovered while adding CI to [alfalfa-notebooks](https://github.com/NatLabRockies/alfalfa-notebooks) that stands up Alfalfa from the `develop`-tagged ghcr images and executes a notebook exercising two custom FMUs.