### PR TITLE
Fix Grafana provisioning format for Grafana v13

### DIFF
--- a/grafana/provisioning/dashboards/all.yml
+++ b/grafana/provisioning/dashboards/all.yml
@@ -1,5 +1,8 @@
-- name: "default"
-  folder: ""
-  type: "file"
-  options:
-    folder: "/var/lib/grafana/dashboards"
+apiVersion: 1
+
+providers:
+  - name: "default"
+    folder: ""
+    type: "file"
+    options:
+      path: "/var/lib/grafana/dashboards"

--- a/grafana/provisioning/datasources/all.yml
+++ b/grafana/provisioning/datasources/all.yml
@@ -8,5 +8,10 @@ datasources:
     url: http://${INFLUXDB_HOST}:8086 # url of the prom instance
     version: 1 # well, versioning
     database: $INFLUXDB_DB
-    user: $INFLUXDB_ADMIN_USER
-    password: $INFLUXDB_ADMIN_PASSWORD
+    # `password` is not a real datasource field (Grafana silently ignores it) --
+    # InfluxDB HTTP auth must be sent as a Basic Auth header, which requires
+    # basicAuth/basicAuthUser + the password in secureJsonData.
+    basicAuth: true
+    basicAuthUser: $INFLUXDB_ADMIN_USER
+    secureJsonData:
+      basicAuthPassword: $INFLUXDB_ADMIN_PASSWORD


### PR DESCRIPTION
## Summary
Updates Grafana provisioning configs for compatibility with Grafana v13 (bumped from 8.5.4 in #629).

- **dashboards/all.yml**: Wraps providers list in the required apiVersion/providers structure and renames folder (data dir) to path, matching the v13 dashboard provisioning schema.
- **datasources/all.yml**: password is not a real datasource field in v13 (Grafana silently ignores it). Switches InfluxDB auth to Basic Auth via basicAuth/basicAuthUser + secureJsonData.basicAuthPassword.

## Test plan
- [ ] Bring up Grafana via docker-compose and confirm dashboards load and the InfluxDB datasource connects successfully.
